### PR TITLE
stop incorrectly using `basedpyright --verifytypes`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ jobs:
           config: ".markdownlint.yaml"
           globs: "**/*.md"
 
-      - name: install poetry
-        run: |
+      - run: |
           pipx install poetry poethepoet
           poetry config virtualenvs.create true --local
           poetry config virtualenvs.in-project true --local
@@ -36,23 +35,17 @@ jobs:
           python-version: "3.10"
           cache: poetry
 
-      - name: poetry install
+      - name: install
         run: poetry install
 
-      - name: ruff check
-        run: poetry run ruff check --output-format=github
+      - name: lint (ruff)
+        run: poe lint --output-format=github
 
-      - name: basedpyright --verifytypes --ignoreexternal
-        run: poetry run basedpyright --ignoreexternal --verifytypes scipy-stubs
-
-      # TODO: don't continue on error
-      - name: basedpyright --verifytypes
-        run: poetry run basedpyright --level error --verifytypes scipy-stubs
-        continue-on-error: true
+      - name: verifytypes (basedpyright)
+        run: poe verifytypes
 
       # TODO: don't continue on error
-      - name: mypy.stubtest (based)
-        # run: poetry run stubtest --concise --ignore-positional-only --mypy-config-file=pyproject.toml --allowlist=tests/stubtest/allowlist.txt scipy
+      - name: stubtest (basedmypy)
         run: poe stubtest -- --concise
         continue-on-error: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ type = "poetry"
 
 [tool.poe.tasks]
 lint = "ruff check"
-verifytypes = "basedpyright --level error --verifytypes scipy-stubs"
+verifytypes = "basedpyright --ignoreexternal --verifytypes scipy-stubs"
 
 [tool.poe.tasks.stubtest]
 cmd = "stubtest --mypy-config-file=pyproject.toml --allowlist=tests/stubtest/allowlist.txt $modules"


### PR DESCRIPTION
Apparantly, it doesn't *verify types*, it just checks a *local package* and propagates all errors from external packages (without providing any means to control this).
So for stub-only packages, `--ignoreexternal` is *always* required for the results to make any sense.