### PR TITLE
stubtest specific packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
+  lint-and-typecheck:
     timeout-minutes: 5
     runs-on: ubuntu-latest
 
@@ -25,18 +25,16 @@ jobs:
           config: ".markdownlint.yaml"
           globs: "**/*.md"
 
-      - run: |
-          pipx install poetry poethepoet
-          poetry config virtualenvs.create true --local
-          poetry config virtualenvs.in-project true --local
-
-      - uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: poetry
 
-      - name: install
-        run: poetry install
+      - name: Install dependencies
+        run: |
+          pipx install poetry poethepoet
+          poetry install
 
       - name: lint (ruff)
         run: poe lint --output-format=github
@@ -47,66 +45,70 @@ jobs:
       - name: verifytypes (basedpyright)
         run: poe verifytypes
 
-      # TODO: scipy._lib
+  stubtest:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module: [
+            # "scipy._lib",
+            "scipy.cluster",
+            "scipy.constants",
+            "scipy.datasets",
+            "scipy.fft",
+            "scipy.fftpack",
+            "scipy.integrate",
+            # "scipy.interpolate",
+            # "scipy.io",
+            "scipy.io.arff scipy.io.matlab",
+            "scipy.linalg",
+            "scipy.misc",
+            # "scipy.ndimage",
+            "scipy.odr",
+            "scipy.optimize",
+            # "scipy.signal",
+            # "scipy.sparse",
+            # "scipy.spatial",
+            "scipy.special",
+            # "scipy.stats",
+            "scipy.stats.contingency scipy.stats.distributions",
+            "scipy.version",
+          ]
+    steps:
+      - uses: actions/checkout@v4
 
-      - name: stubtest scipy.cluster
-        run: poe stubtest scipy.cluster -- --ignore-unused-allowlist
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: poetry
 
-      - name: stubtest scipy.constants
-        run: poe stubtest scipy.constants -- --ignore-unused-allowlist
+      - name: Install dependencies
+        run: |
+          pipx install poetry poethepoet
+          poetry install
 
-      - name: stubtest scipy.datasets
-        run: poe stubtest scipy.datasets -- --ignore-unused-allowlist
+      - name: Run stubtest for ${{ matrix.module }}
+        run: poe stubtest ${{ matrix.module }} -- --ignore-unused-allowlist
 
-      - name: stubtest scipy.fft scipy.fftpack
-        run: poe stubtest scipy.fft scipy.fftpack -- --ignore-unused-allowlist
+  stubtest-all:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-      - name: stubtest scipy.integrate
-        run: poe stubtest scipy.integrate -- --ignore-unused-allowlist
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: poetry
 
-      # TODO: scipy.interpolate
-      # TODO: scipy.io
+      - name: Install dependencies
+        run: |
+          pipx install poetry poethepoet
+          poetry install
 
-      - name: stubtest scipy.io.arff scipy.io.matlab
-        run: poe stubtest scipy.io.arff scipy.io.matlab -- --ignore-unused-allowlist
-
-      - name: stubtest scipy.linalg
-        run: poe stubtest scipy.linalg -- --ignore-unused-allowlist
-
-      - name: stubtest scipy.misc
-        run: poe stubtest scipy.misc -- --ignore-unused-allowlist
-
-      # TODO: scipy.ndimage
-
-      - name: stubtest scipy.odr
-        run: poe stubtest scipy.odr -- --ignore-unused-allowlist
-
-      - name: stubtest scipy.optimize
-        run: poe stubtest scipy.optimize -- --ignore-unused-allowlist
-
-      # TODO: scipy.signal
-      # TODO: scipy.sparse
-      # TODO: scipy.spatial
-
-      - name: stubtest scipy.special
-        run: poe stubtest scipy.special -- --ignore-unused-allowlist
-
-      # TODO: scipy.stats
-
-      - name: stubtest scipy.stats.contingency
-        run: poe stubtest scipy.stats.contingency -- --ignore-unused-allowlist
-
-      - name: stubtest scipy.stats.distributions
-        run: poe stubtest scipy.stats.distributions -- --ignore-unused-allowlist
-
-      # TODO: scipy.stats.mstats
-      # TODO: scipy.stats.qmc
-      # TODO: scipy.stats.sampling
-
-      - name: stubtest scipy.version
-        run: poe stubtest scipy.version -- --ignore-unused-allowlist
-
-      # TODO: scipy
-      - name: stubtest scipy (ignored)
+      - name: Run stubtest (ignored)
         run: poe stubtest -- --concise
-        continue-on-error: true  # TODO
+        continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,18 +41,72 @@ jobs:
       - name: lint (ruff)
         run: poe lint --output-format=github
 
-      - name: verifytypes (basedpyright)
-        run: poe verifytypes
-
-      # TODO: don't continue on error
-      - name: stubtest (basedmypy)
-        run: poe stubtest -- --concise
-        continue-on-error: true
-
       - name: typetest
         run: poe typetest
 
-      # TODO
-      # - uses: scientific-python/repo-review@v0.11.2
-      #   with:
-      #     plugins: sp-repo-review
+      - name: verifytypes (basedpyright)
+        run: poe verifytypes
+
+      # TODO: scipy._lib
+
+      - name: stubtest scipy.cluster
+        run: poe stubtest scipy.cluster -- --ignore-unused-allowlist
+
+      - name: stubtest scipy.constants
+        run: poe stubtest scipy.constants -- --ignore-unused-allowlist
+
+      - name: stubtest scipy.datasets
+        run: poe stubtest scipy.datasets -- --ignore-unused-allowlist
+
+      - name: stubtest scipy.fft scipy.fftpack
+        run: poe stubtest scipy.fft scipy.fftpack -- --ignore-unused-allowlist
+
+      - name: stubtest scipy.integrate
+        run: poe stubtest scipy.integrate -- --ignore-unused-allowlist
+
+      # TODO: scipy.interpolate
+      # TODO: scipy.io
+
+      - name: stubtest scipy.io.arff scipy.io.matlab
+        run: poe stubtest scipy.io.arff scipy.io.matlab -- --ignore-unused-allowlist
+
+      - name: stubtest scipy.linalg
+        run: poe stubtest scipy.linalg -- --ignore-unused-allowlist
+
+      - name: stubtest scipy.misc
+        run: poe stubtest scipy.misc -- --ignore-unused-allowlist
+
+      # TODO: scipy.ndimage
+
+      - name: stubtest scipy.odr
+        run: poe stubtest scipy.odr -- --ignore-unused-allowlist
+
+      - name: stubtest scipy.optimize
+        run: poe stubtest scipy.optimize -- --ignore-unused-allowlist
+
+      # TODO: scipy.signal
+      # TODO: scipy.sparse
+      # TODO: scipy.spatial
+
+      - name: stubtest scipy.special
+        run: poe stubtest scipy.special -- --ignore-unused-allowlist
+
+      # TODO: scipy.stats
+
+      - name: stubtest scipy.stats.contingency
+        run: poe stubtest scipy.stats.contingency -- --ignore-unused-allowlist
+
+      - name: stubtest scipy.stats.distributions
+        run: poe stubtest scipy.stats.distributions -- --ignore-unused-allowlist
+
+      # TODO: scipy.stats.mstats
+      # TODO: scipy.stats.qmc
+      # TODO: scipy.stats.sampling
+
+      - name: stubtest scipy.version
+        run: poe stubtest scipy.version -- --ignore-unused-allowlist
+
+      # TODO: scipy
+      - name: stubtest scipy (ignored)
+        run: poe stubtest -- --concise
+        continue-on-error: true  # TODO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,18 @@ jobs:
           config: ".markdownlint.yaml"
           globs: "**/*.md"
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - run: |
+          pipx install poetry poethepoet
+          poetry config virtualenvs.create true --local
+          poetry config virtualenvs.in-project true --local
+
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: poetry
 
-      - name: Install dependencies
-        run: |
-          pipx install poetry poethepoet
-          poetry install
+      - name: install
+        run: poetry install
 
       - name: lint (ruff)
         run: poe lint --output-format=github
@@ -46,48 +48,51 @@ jobs:
         run: poe verifytypes
 
   stubtest:
-    timeout-minutes: 5
+    needs: lint-and-typecheck
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         module: [
-            # "scipy._lib",
-            "scipy.cluster",
-            "scipy.constants",
-            "scipy.datasets",
-            "scipy.fft",
-            "scipy.fftpack",
-            "scipy.integrate",
-            # "scipy.interpolate",
-            # "scipy.io",
-            "scipy.io.arff scipy.io.matlab",
-            "scipy.linalg",
-            "scipy.misc",
-            # "scipy.ndimage",
-            "scipy.odr",
-            "scipy.optimize",
-            # "scipy.signal",
-            # "scipy.sparse",
-            # "scipy.spatial",
-            "scipy.special",
-            # "scipy.stats",
-            "scipy.stats.contingency scipy.stats.distributions",
-            "scipy.version",
-          ]
+          # "scipy._lib",
+          "scipy.cluster",
+          "scipy.constants",
+          "scipy.datasets",
+          "scipy.fft",
+          "scipy.fftpack",
+          "scipy.integrate",
+          # "scipy.interpolate",
+          # "scipy.io",
+          "scipy.io.arff scipy.io.matlab",
+          "scipy.linalg",
+          "scipy.misc",
+          # "scipy.ndimage",
+          "scipy.odr",
+          "scipy.optimize",
+          # "scipy.signal",
+          # "scipy.sparse",
+          # "scipy.spatial",
+          "scipy.special",
+          # "scipy.stats",
+          "scipy.stats.contingency scipy.stats.distributions",
+          "scipy.version"
+        ]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - run: |
+          pipx install poetry poethepoet
+          poetry config virtualenvs.create true --local
+          poetry config virtualenvs.in-project true --local
+
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
           cache: poetry
 
-      - name: Install dependencies
-        run: |
-          pipx install poetry poethepoet
-          poetry install
+      - name: install
+        run: poetry install
 
       - name: Run stubtest for ${{ matrix.module }}
         run: poe stubtest ${{ matrix.module }} -- --ignore-unused-allowlist
@@ -98,16 +103,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - run: |
+          pipx install poetry poethepoet
+          poetry config virtualenvs.create true --local
+          poetry config virtualenvs.in-project true --local
+
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
           cache: poetry
 
-      - name: Install dependencies
-        run: |
-          pipx install poetry poethepoet
-          poetry install
+      - name: install
+        run: poetry install
 
       - name: Run stubtest (ignored)
         run: poe stubtest -- --concise

--- a/README.md
+++ b/README.md
@@ -108,29 +108,28 @@ The exact version requirements are specified in the [`pyproject.toml`](pyproject
 |---------------------------------- |---------------- |
 | `scipy.__init__`                  | 3: ready        |
 | `scipy._lib`                      | 2: partial      |
-| `scipy.cluster.vq`                | **4: done**     |
-| `scipy.cluster.hierarchy`         | **4: done**     |
+| `scipy.cluster`                   | **4: done**     |
 | `scipy.constants`                 | **4: done**     |
 | `scipy.datasets`                  | **4: done**     |
-| `scipy.fft`                       | 2: partial      |
-| `scipy.fftpack`                   | 2: partial      |
+| `scipy.fft`                       | 3: ready        |
+| `scipy.fftpack`                   | 3: ready        |
 | `scipy.integrate`                 | **4: done**     |
 | `scipy.interpolate`               | 2: partial      |
 | `scipy.io`                        | 2: partial      |
-| `scipy.io.arff`                   | 2: partial      |
-| `scipy.io.matlab`                 | 2: partial      |
+| `scipy.io.arff`                   | 3: ready        |
+| `scipy.io.matlab`                 | 3: ready        |
 | `scipy.linalg`                    | **4: done**     |
 | ~`scipy.misc`~                    | **4: done**     |
 | `scipy.ndimage`                   | 2: partial      |
-| `scipy.odr`                       | 1: skeleton     |
-| `scipy.optimize`                  | 2: partial      |
+| `scipy.odr`                       | 3: ready        |
+| `scipy.optimize`                  | 3: ready        |
 | `scipy.signal`                    | 2: partial      |
 | `scipy.signal.windows`            | 1: skeleton     |
 | `scipy.sparse`                    | 2: partial      |
 | `scipy.sparse.csgraph`            | 2: partial      |
 | `scipy.sparse.linalg`             | 2: partial      |
 | `scipy.spatial`                   | 2: partial      |
-| `scipy.spatial.distance`          | 3: ready        |
+| `scipy.spatial.distance`          | 2: partial      |
 | `scipy.special`                   | **4: done**     |
 | `scipy.special.cython_special`    | **4: done**     |
 | `scipy.stats`                     | 2: partial      |
@@ -143,8 +142,7 @@ The exact version requirements are specified in the [`pyproject.toml`](pyproject
 
 Status labels:
 
-- 0: missing (failed stubgen)
-- 1: skeleton (mostly succesful stubgen)
-- 2: partial (incomplete/broad annotations)
-- 3: ready (complete & valid annotations, untested)
-- 4: done (complete, valid, tested, and production-ready)
+1. skeleton (mostly succesful stubgen)
+2. partial (incomplete/broad annotations)
+3. ready (passes stubtest)
+4. done (complete, valid, tested, and production-ready)

--- a/tests/stubtest/allowlist.txt
+++ b/tests/stubtest/allowlist.txt
@@ -99,8 +99,9 @@ scipy.stats.mstats_basic.*
 scipy.stats.mstats_extras.*
 scipy.stats.stats.*
 
-# random mypy hallucinations
+# mypy hallucinations
 scipy._lib._ccallback.PyCFuncPtr  # `final(T)` is impossible
+scipy.integrate._quadrature.QMCQuadResult.__replace__  # bruh...
 scipy.interpolate.AAA
 scipy.interpolate._aaa
 scipy.interpolate._interpnd_info


### PR DESCRIPTION
the following `scipy` packages are now required pass stubtest:

- `.cluster`
- `.constants`
- `.datasets`
- `.fft`
- `.fftpack`
- `.integrate`
- `.io.arff`, `.io.matlab`
- `.linalg`
- `.misc`
- `.odr`
- `.optimize`
- `.special`
- `.stats.contingency`, `.stats.distributions`
- `.version`