### PR TITLE
fix version number and stop using `verifytypes`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,6 @@ jobs:
       - name: typetest
         run: poe typetest
 
-      - name: verifytypes
-        run: poe verifytypes
-
       - name: typecheck (partial)
         run: |
           targets=(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,12 +56,6 @@ repos:
 
   - repo: local
     hooks:
-      - id: verifytypes
-        name: poe verifytypes
-        entry: poe verifytypes
-        language: system
-        always_run: true
-        pass_filenames: false
       - id: typetest
         name: poe typetest
         entry: poe typetest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ name = "scipy-stubs"
 packages = [{include = "scipy-stubs"}]
 readme = "README.md"
 repository = "https://github.com/jorenham/scipy-stubs/"
-version = "1.4.1a4.dev0"
+version = "1.14.1.0.dev0"
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/jorenham/scipy-stubs/issues"
@@ -30,8 +30,8 @@ version = "1.4.1a4.dev0"
 
 [tool.poetry.dependencies]
 python = "^3.10.1"
-optype = "^0.6.1"
 scipy = "^1.14.1"
+optype = "^0.6.1"
 
 [tool.poetry.group.lint.dependencies]
 basedmypy = "^2.6.0"
@@ -64,14 +64,10 @@ typetest = ["_typetest_bpr", "_typetest_mypy"]
 
 [tool.poe.tasks.pyright]
 cmd = "basedpyright scipy-stubs/$path"
-args = [{name = "path", positional = true, multiple = true, default = ""}]
+args = [{name = "path", positional = true, multiple = false, default = ""}]
 
 [tool.poe.tasks.mypy]
 cmd = "mypy --config-file=pyproject.toml scipy-stubs/$path"
-args = [{name = "path", positional = true, multiple = false, default = ""}]
-
-[tool.poe.tasks.verifytypes]
-cmd = "basedpyright --ignoreexternal --verifytypes scipy-stubs/$path"
 args = [{name = "path", positional = true, multiple = false, default = ""}]
 
 [tool.poe.tasks.stubtest]


### PR DESCRIPTION
- sync the `scipy-stubs` version to that of `scipy`, currently `1.14.1.0.dev0`
- stop using `pyright --verifytypes`: it's irrrelevant for stub-only packages
- remove the `py.typed`, because according to the [typing spec](https://typing.readthedocs.io/en/latest/spec/distributing.html#stub-only-packages):
  > For stub-only packages adding a py.typed marker is not needed since the name *-stubs is 
  enough to indicate it is a source of typing information.
