### PR TITLE
improved `scipy.LowLevelCallable`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -460,31 +460,6 @@ files = [
 ]
 
 [[package]]
-name = "types-cffi"
-version = "1.16.0.20240331"
-description = "Typing stubs for cffi"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "types-cffi-1.16.0.20240331.tar.gz", hash = "sha256:b8b20d23a2b89cfed5f8c5bc53b0cb8677c3aac6d970dbc771e28b9c698f5dee"},
-    {file = "types_cffi-1.16.0.20240331-py3-none-any.whl", hash = "sha256:a363e5ea54a4eb6a4a105d800685fde596bc318089b025b27dee09849fe41ff0"},
-]
-
-[package.dependencies]
-types-setuptools = "*"
-
-[[package]]
-name = "types-setuptools"
-version = "75.1.0.20240917"
-description = "Typing stubs for setuptools"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "types-setuptools-75.1.0.20240917.tar.gz", hash = "sha256:12f12a165e7ed383f31def705e5c0fa1c26215dd466b0af34bd042f7d5331f55"},
-    {file = "types_setuptools-75.1.0.20240917-py3-none-any.whl", hash = "sha256:06f78307e68d1bbde6938072c57b81cf8a99bc84bd6dc7e4c5014730b097dc0c"},
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -518,4 +493,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10.1"
-content-hash = "3a1d2c336059f7c70d5bfe3a8dc1a7a1431796d534468e156108bc7fed37bac0"
+content-hash = "6dd822e187f3caee0d4062af6393e69f0f40d65169d7622c7f9287a9dd98b63b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ python = "^3.10.1"
 numpy = ">=1.25"
 scipy = ">=1.14.1"
 optype = "^0.6.1"
-types-cffi = ">=1.16.0"
 
 [tool.poetry.group.lint.dependencies]
 basedmypy = "^2.6.0"


### PR DESCRIPTION
this also removes the need for the (mostly incomplete) `types-cffi` dependency