### PR TITLE
explicit python version pypi classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ packages = [{include = "scipy-stubs"}]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Stubs Only",
     "Typing :: Typed",
 ]


### PR DESCRIPTION
because `poetry` will otherwise leave `3.10` out