### PR TITLE
complete `scipy.signal._savitzky_golay`

### DIFF
--- a/scipy-stubs/signal/_savitzky_golay.pyi
+++ b/scipy-stubs/signal/_savitzky_golay.pyi
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.typing as npt
 import optype as op
 
-_Array_fc_1d: TypeAlias = np.ndarray[tuple[int], np.dtype[np.inexact[npt.NBitBase]]]
+_Array_f_1d: TypeAlias = np.ndarray[tuple[int], np.dtype[np.floating[npt.NBitBase]]]
 _Mode: TypeAlias = Literal["mirror", "constant", "nearest", "wrap", "interp"]
 
 def savgol_coeffs(
@@ -14,7 +14,7 @@ def savgol_coeffs(
     delta: float = 1.0,
     pos: int | None = None,
     use: Literal["conv", "dot"] = "conv",
-) -> _Array_fc_1d: ...
+) -> _Array_f_1d: ...
 def savgol_filter(
     x: npt.ArrayLike,
     window_length: int,

--- a/scipy-stubs/signal/_savitzky_golay.pyi
+++ b/scipy-stubs/signal/_savitzky_golay.pyi
@@ -1,4 +1,10 @@
+from typing import Literal, TypeAlias
+
+import numpy as np
+import numpy.typing as npt
 from scipy._typing import Untyped, UntypedArray
+
+_Array_fc_1d: TypeAlias = np.ndarray[tuple[int], np.dtype[np.inexact[npt.NBitBase]]]
 
 def savgol_coeffs(
     window_length: int,
@@ -6,8 +12,8 @@ def savgol_coeffs(
     deriv: int = 0,
     delta: float = 1.0,
     pos: int | None = None,
-    use: str = "conv",
-) -> UntypedArray: ...
+    use: Literal["conv", "dot"] = "conv",
+) -> _Array_fc_1d: ...
 def savgol_filter(
     x: Untyped,
     window_length: int,

--- a/scipy-stubs/signal/_savitzky_golay.pyi
+++ b/scipy-stubs/signal/_savitzky_golay.pyi
@@ -2,6 +2,7 @@ from typing import Literal, TypeAlias
 
 import numpy as np
 import numpy.typing as npt
+import optype as op
 
 _Array_fc_1d: TypeAlias = np.ndarray[tuple[int], np.dtype[np.inexact[npt.NBitBase]]]
 _Mode: TypeAlias = Literal["mirror", "constant", "nearest", "wrap", "interp"]
@@ -20,7 +21,7 @@ def savgol_filter(
     polyorder: int,
     deriv: int = 0,
     delta: float = 1.0,
-    axis: int = -1,
+    axis: op.CanIndex = -1,
     mode: _Mode = "interp",
     cval: float = 0.0,
 ) -> npt.NDArray[np.float32 | np.float64]: ...

--- a/scipy-stubs/signal/_savitzky_golay.pyi
+++ b/scipy-stubs/signal/_savitzky_golay.pyi
@@ -2,9 +2,9 @@ from typing import Literal, TypeAlias
 
 import numpy as np
 import numpy.typing as npt
-from scipy._typing import Untyped, UntypedArray
 
 _Array_fc_1d: TypeAlias = np.ndarray[tuple[int], np.dtype[np.inexact[npt.NBitBase]]]
+_Mode: TypeAlias = Literal["mirror", "constant", "nearest", "wrap", "interp"]
 
 def savgol_coeffs(
     window_length: int,
@@ -15,12 +15,12 @@ def savgol_coeffs(
     use: Literal["conv", "dot"] = "conv",
 ) -> _Array_fc_1d: ...
 def savgol_filter(
-    x: Untyped,
+    x: npt.ArrayLike,
     window_length: int,
     polyorder: int,
     deriv: int = 0,
     delta: float = 1.0,
     axis: int = -1,
-    mode: str = "interp",
+    mode: _Mode = "interp",
     cval: float = 0.0,
-) -> UntypedArray: ...
+) -> npt.NDArray[np.float32 | np.float64]: ...


### PR DESCRIPTION
Before this PR, the stub file `_savitzky_golay.pyi` had untyped annotations. This PR adds in the missing type annotations and improves previous ones.

The improvements are:
1. Use `op.CanIndex` instead of `int` for the `axis` parameter.
2. Use Literals to type hint certain strings for `use` and `mode` parameters

This file tends to use `int` and `float` a lot which could perhaps be replaced by `AnyInt` and `AnyReal` however, some parameters like `window_length` are used as shapes in calls to functions like `np.zeros` which don't accept `np.bool_`.

For simplicity I left the type annotations as the builtin python types but I am open to using more general type annotations to allow numpy dtypes as well. It just might take a bit more testing to check the allowed types.