### PR TITLE
`signal`: Add type stubs to `_spectral_py.pyi`.

### DIFF
--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias
+from typing import Any, Literal, TypeAlias, overload
 from typing_extensions import Unpack
 
 import numpy as np
@@ -11,7 +11,10 @@ from scipy.signal.windows._windows import _Window, _WindowNeedsParams
 
 __all__ = ["check_COLA", "check_NOLA", "coherence", "csd", "istft", "lombscargle", "periodogram", "spectrogram", "stft", "welch"]
 
+_Array_f8: TypeAlias = npt.NDArray[np.float64]
 _Array_f8_1d: TypeAlias = np.ndarray[tuple[int], np.dtype[np.float64]]
+_ArrayReal: TypeAlias = npt.NDArray[np.floating[Any]]
+_ArrayComplex: TypeAlias = npt.NDArray[np.complexfloating[Any, Any]]
 
 _GetWindowArgument: TypeAlias = _Window | tuple[_Window | _WindowNeedsParams, Unpack[tuple[object, ...]]]
 _Detrend: TypeAlias = Literal["literal", "constant", False] | Callable[[npt.NDArray[np.generic]], npt.NDArray[np.generic]]
@@ -37,7 +40,7 @@ def periodogram(
     return_onesided: op.CanBool = True,
     scaling: _Scaling = "density",
     axis: op.CanIndex = -1,
-) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.floating[Any]]]: ...
+) -> tuple[_Array_f8, _ArrayReal]: ...
 def welch(
     x: _ArrayLikeComplex_co,
     fs: AnyReal = 1.0,
@@ -50,7 +53,7 @@ def welch(
     scaling: _Scaling = "density",
     axis: op.CanIndex = -1,
     average: _Average = "mean",
-) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.floating[Any]]]: ...
+) -> tuple[_Array_f8, _ArrayReal]: ...
 def csd(
     x: _ArrayLikeComplex_co,
     y: _ArrayLikeComplex_co,
@@ -64,20 +67,59 @@ def csd(
     scaling: _Scaling = "density",
     axis: op.CanIndex = -1,
     average: _Average = "mean",
-) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.complexfloating[Any, Any]]]: ...
+) -> tuple[_Array_f8, _ArrayComplex]: ...
+
+#
+@overload
 def spectrogram(
-    x: Untyped,
-    fs: float = 1.0,
-    window: Untyped = ("tukey", 0.25),
-    nperseg: int | None = None,
-    noverlap: int | None = None,
-    nfft: int | None = None,
-    detrend: str | Literal[False] | UntypedCallable = "constant",
-    return_onesided: bool = True,
-    scaling: str = "density",
-    axis: int = -1,
-    mode: str = "psd",
-) -> Untyped: ...
+    x: npt.NDArray[np.generic],
+    fs: AnyReal = 1.0,
+    window: _GetWindowArgument | _ArrayLikeFloat_co = ("tukey", 0.25),
+    nperseg: AnyInt | None = None,
+    noverlap: AnyInt | None = None,
+    nfft: AnyInt | None = None,
+    detrend: _Detrend = "constant",
+    return_onesided: op.CanBool = True,
+    scaling: _Scaling = "density",
+    axis: op.CanIndex = -1,
+    mode: Literal["psd", "magnitude", "angle", "phase"] = "psd",
+) -> tuple[_Array_f8, _Array_f8, _ArrayReal]: ...
+
+# complex mode (positional)
+@overload
+def spectrogram(
+    x: npt.NDArray[np.generic],
+    fs: AnyReal,
+    window: _GetWindowArgument | _ArrayLikeFloat_co,
+    nperseg: AnyInt | None,
+    noverlap: AnyInt | None,
+    nfft: AnyInt | None,
+    detrend: _Detrend,
+    return_onesided: op.CanBool,
+    scaling: _Scaling,
+    axis: op.CanIndex,
+    mode: Literal["complex"],
+) -> tuple[_Array_f8, _Array_f8, _ArrayComplex]: ...
+
+# complex mode (keyword)
+
+@overload
+def spectrogram(
+    x: npt.NDArray[np.generic],
+    fs: AnyReal = 1.0,
+    window: _GetWindowArgument | _ArrayLikeFloat_co = ("tukey", 0.25),
+    nperseg: AnyInt | None = None,
+    noverlap: AnyInt | None = None,
+    nfft: AnyInt | None = None,
+    detrend: _Detrend = "constant",
+    return_onesided: op.CanBool = True,
+    scaling: _Scaling = "density",
+    axis: op.CanIndex = -1,
+    *,
+    mode: Literal["complex"],
+) -> tuple[_Array_f8, _Array_f8, _ArrayComplex]: ...
+
+#
 def check_COLA(
     window: _GetWindowArgument | _ArrayLikeFloat_co,
     nperseg: AnyInt,

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -17,6 +17,7 @@ _ArrayFloat: TypeAlias = npt.NDArray[np.float32 | np.float64 | np.longdouble]
 _ArrayComplex: TypeAlias = npt.NDArray[np.complex64 | np.complex128 | np.clongdouble]
 
 _GetWindowArgument: TypeAlias = _Window | tuple[_Window | _WindowNeedsParams, Unpack[tuple[object, ...]]]
+_WindowLike: TypeAlias = _GetWindowArgument | _ArrayLikeFloat_co
 _Detrend: TypeAlias = Literal["literal", "constant", False] | Callable[[npt.NDArray[np.generic]], npt.NDArray[np.generic]]
 _Scaling: TypeAlias = Literal["density", "spectrum"]
 _LegacyScaling: TypeAlias = Literal["psd", "spectrum"]
@@ -33,7 +34,7 @@ def lombscargle(
 def periodogram(
     x: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
-    window: _GetWindowArgument | _ArrayLikeFloat_co | None = "boxcar",
+    window: _WindowLike | None = "boxcar",
     nfft: AnyInt | None = None,
     detrend: _Detrend = "constant",
     return_onesided: op.CanBool = True,
@@ -43,7 +44,7 @@ def periodogram(
 def welch(
     x: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
-    window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
+    window: _WindowLike = "hann",
     nperseg: AnyInt | None = None,
     noverlap: AnyInt | None = None,
     nfft: AnyInt | None = None,
@@ -57,7 +58,7 @@ def csd(
     x: _ArrayLikeNumber_co,
     y: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
-    window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
+    window: _WindowLike = "hann",
     nperseg: AnyInt | None = None,
     noverlap: AnyInt | None = None,
     nfft: AnyInt | None = None,
@@ -74,7 +75,7 @@ def csd(
 def spectrogram(
     x: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
-    window: _GetWindowArgument | _ArrayLikeFloat_co = ("tukey", 0.25),
+    window: _WindowLike = ("tukey", 0.25),
     nperseg: AnyInt | None = None,
     noverlap: AnyInt | None = None,
     nfft: AnyInt | None = None,
@@ -89,7 +90,7 @@ def spectrogram(
 def spectrogram(
     x: _ArrayLikeNumber_co,
     fs: AnyReal,
-    window: _GetWindowArgument | _ArrayLikeFloat_co,
+    window: _WindowLike,
     nperseg: AnyInt | None,
     noverlap: AnyInt | None,
     nfft: AnyInt | None,
@@ -104,7 +105,7 @@ def spectrogram(
 def spectrogram(
     x: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
-    window: _GetWindowArgument | _ArrayLikeFloat_co = ("tukey", 0.25),
+    window: _WindowLike = ("tukey", 0.25),
     nperseg: AnyInt | None = None,
     noverlap: AnyInt | None = None,
     nfft: AnyInt | None = None,
@@ -118,13 +119,13 @@ def spectrogram(
 
 #
 def check_COLA(
-    window: _GetWindowArgument | _ArrayLikeFloat_co,
+    window: _WindowLike,
     nperseg: AnyInt,
     noverlap: AnyInt,
     tol: AnyReal = 1e-10,
 ) -> np.bool_: ...
 def check_NOLA(
-    window: _GetWindowArgument | _ArrayLikeFloat_co,
+    window: _WindowLike,
     nperseg: AnyInt,
     noverlap: AnyInt,
     tol: AnyReal = 1e-10,
@@ -132,7 +133,7 @@ def check_NOLA(
 def stft(
     x: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
-    window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
+    window: _WindowLike = "hann",
     nperseg: AnyInt = 256,
     noverlap: AnyInt | None = None,
     nfft: AnyInt | None = None,
@@ -150,7 +151,7 @@ def stft(
 def istft(
     Zxx: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
-    window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
+    window: _WindowLike = "hann",
     nperseg: AnyInt | None = None,
     noverlap: AnyInt | None = None,
     nfft: AnyInt | None = None,
@@ -165,7 +166,7 @@ def istft(
 def istft(
     Zxx: _ArrayLikeNumber_co,
     fs: AnyReal,
-    window: _GetWindowArgument | _ArrayLikeFloat_co,
+    window: _WindowLike,
     nperseg: AnyInt | None,
     noverlap: AnyInt | None,
     nfft: AnyInt | None,
@@ -180,7 +181,7 @@ def istft(
 def istft(
     Zxx: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
-    window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
+    window: _WindowLike = "hann",
     nperseg: AnyInt | None = None,
     noverlap: AnyInt | None = None,
     nfft: AnyInt | None = None,
@@ -197,7 +198,7 @@ def coherence(
     x: _ArrayLikeNumber_co,
     y: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
-    window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
+    window: _WindowLike = "hann",
     nperseg: AnyInt | None = None,
     noverlap: AnyInt | None = None,
     nfft: AnyInt | None = None,

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias, overload
+from typing import Literal, TypeAlias, overload
 from typing_extensions import Unpack
 
 import numpy as np
@@ -11,10 +11,10 @@ from .windows._windows import _Window, _WindowNeedsParams
 
 __all__ = ["check_COLA", "check_NOLA", "coherence", "csd", "istft", "lombscargle", "periodogram", "spectrogram", "stft", "welch"]
 
-_Array_f: TypeAlias = npt.NDArray[np.floating[Any]]
 _Array_f8: TypeAlias = npt.NDArray[np.float64]
 _Array_f8_1d: TypeAlias = np.ndarray[tuple[int], np.dtype[np.float64]]
-_ArrayComplex: TypeAlias = npt.NDArray[np.complexfloating[Any, Any]]
+_ArrayFloat: TypeAlias = npt.NDArray[np.float32 | np.float64 | np.float128]
+_ArrayComplex: TypeAlias = npt.NDArray[np.complex64 | np.complex128 | np.complex256]
 
 _GetWindowArgument: TypeAlias = _Window | tuple[_Window | _WindowNeedsParams, Unpack[tuple[object, ...]]]
 _Detrend: TypeAlias = Literal["literal", "constant", False] | Callable[[npt.NDArray[np.generic]], npt.NDArray[np.generic]]
@@ -39,7 +39,7 @@ def periodogram(
     return_onesided: op.CanBool = True,
     scaling: _Scaling = "density",
     axis: op.CanIndex = -1,
-) -> tuple[_Array_f8, _Array_f]: ...
+) -> tuple[_Array_f8, _ArrayFloat]: ...
 def welch(
     x: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
@@ -52,7 +52,7 @@ def welch(
     scaling: _Scaling = "density",
     axis: op.CanIndex = -1,
     average: _Average = "mean",
-) -> tuple[_Array_f8, _Array_f]: ...
+) -> tuple[_Array_f8, _ArrayFloat]: ...
 def csd(
     x: _ArrayLikeNumber_co,
     y: _ArrayLikeNumber_co,
@@ -83,7 +83,7 @@ def spectrogram(
     scaling: _Scaling = "density",
     axis: op.CanIndex = -1,
     mode: Literal["psd", "magnitude", "angle", "phase"] = "psd",
-) -> tuple[_Array_f8, _Array_f8, _Array_f]: ...
+) -> tuple[_Array_f8, _Array_f8, _ArrayFloat]: ...
 @overload
 # complex mode (positional)
 def spectrogram(
@@ -159,7 +159,7 @@ def istft(
     time_axis: op.CanIndex = -1,
     freq_axis: op.CanIndex = -2,
     scaling: _LegacyScaling = "spectrum",
-) -> tuple[_Array_f8, _Array_f]: ...
+) -> tuple[_Array_f8, _ArrayFloat]: ...
 @overload
 # input_onesided is `False` (positional)
 def istft(
@@ -203,4 +203,4 @@ def coherence(
     nfft: AnyInt | None = None,
     detrend: _Detrend = "constant",
     axis: op.CanIndex = -1,
-) -> tuple[_Array_f8, _Array_f]: ...
+) -> tuple[_Array_f8, _ArrayFloat]: ...

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -13,8 +13,8 @@ __all__ = ["check_COLA", "check_NOLA", "coherence", "csd", "istft", "lombscargle
 
 _Array_f8: TypeAlias = npt.NDArray[np.float64]
 _Array_f8_1d: TypeAlias = np.ndarray[tuple[int], np.dtype[np.float64]]
-_ArrayFloat: TypeAlias = npt.NDArray[np.float32 | np.float64 | np.float128]
-_ArrayComplex: TypeAlias = npt.NDArray[np.complex64 | np.complex128 | np.complex256]
+_ArrayFloat: TypeAlias = npt.NDArray[np.float32 | np.float64 | np.longdouble]
+_ArrayComplex: TypeAlias = npt.NDArray[np.complex64 | np.complex128 | np.clongdouble]
 
 _GetWindowArgument: TypeAlias = _Window | tuple[_Window | _WindowNeedsParams, Unpack[tuple[object, ...]]]
 _Detrend: TypeAlias = Literal["literal", "constant", False] | Callable[[npt.NDArray[np.generic]], npt.NDArray[np.generic]]

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -23,7 +23,6 @@ _LegacyScaling: TypeAlias = Literal["psd", "spectrum"]
 _Average: TypeAlias = Literal["mean", "median"]
 _Boundary: TypeAlias = Literal["even", "odd", "constant", "zeros"] | None
 
-# NOTE(pavyamsiri): This function was actually recently updated, adding new arguments and return types.
 def lombscargle(
     x: _ArrayLikeFloat_co,
     y: _ArrayLikeFloat_co,
@@ -31,8 +30,6 @@ def lombscargle(
     precenter: op.CanBool = False,
     normalize: op.CanBool = False,
 ) -> _Array_f8_1d: ...
-
-# NOTE(pavyamsiri): The docs don't allow `None` for `window` but the body does?
 def periodogram(
     x: _ArrayLikeComplex_co,
     fs: AnyReal = 1.0,
@@ -148,20 +145,6 @@ def stft(
     axis: op.CanIndex = -1,
     scaling: _LegacyScaling = "spectrum",
 ) -> tuple[_Array_f8, _Array_f8, _ArrayComplex]: ...
-
-# def istft(
-#     Zxx: _ArrayLikeComplex_co,
-#     fs: AnyReal = 1.0,
-#     window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
-#     nperseg: AnyInt | None = None,
-#     noverlap: AnyInt | None = None,
-#     nfft: AnyInt | None = None,
-#     input_onesided: op.CanBool = True,
-#     boundary: op.CanBool = True,
-#     time_axis: op.CanIndex = -1,
-#     freq_axis: op.CanIndex = -2,
-#     scaling: _LegacyScaling = "spectrum",
-# ) -> tuple[_Array_f8]: ...
 
 # input_onesided is `True`
 @overload

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -1,8 +1,14 @@
-from typing import Literal
+from typing import Literal, TypeAlias
+from typing_extensions import Unpack
 
-from scipy._typing import Untyped, UntypedCallable
+import optype as op
+from numpy._typing import _ArrayLikeFloat_co
+from scipy._typing import AnyInt, AnyReal, Untyped, UntypedCallable
+from scipy.signal.windows._windows import _Window, _WindowNeedsParams
 
 __all__ = ["check_COLA", "check_NOLA", "coherence", "csd", "istft", "lombscargle", "periodogram", "spectrogram", "stft", "welch"]
+
+_GetWindowArgument: TypeAlias = _Window | tuple[_Window | _WindowNeedsParams, Unpack[tuple[object, ...]]]
 
 def lombscargle(x: Untyped, y: Untyped, freqs: Untyped, precenter: bool = False, normalize: bool = False) -> Untyped: ...
 def periodogram(
@@ -55,8 +61,18 @@ def spectrogram(
     axis: int = -1,
     mode: str = "psd",
 ) -> Untyped: ...
-def check_COLA(window: Untyped, nperseg: int, noverlap: int, tol: float = 1e-10) -> Untyped: ...
-def check_NOLA(window: Untyped, nperseg: int, noverlap: int, tol: float = 1e-10) -> Untyped: ...
+def check_COLA(
+    window: _GetWindowArgument | _ArrayLikeFloat_co,
+    nperseg: AnyInt,
+    noverlap: AnyInt,
+    tol: AnyReal = 1e-10,
+) -> bool: ...
+def check_NOLA(
+    window: _GetWindowArgument | _ArrayLikeFloat_co,
+    nperseg: AnyInt,
+    noverlap: AnyInt,
+    tol: AnyReal = 1e-10,
+) -> bool: ...
 def stft(
     x: Untyped,
     fs: float = 1.0,

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.typing as npt
 import optype as op
 from numpy._typing import _ArrayLikeComplex_co, _ArrayLikeFloat_co
-from scipy._typing import AnyInt, AnyReal, Untyped, UntypedCallable
+from scipy._typing import AnyInt, AnyReal
 from scipy.signal.windows._windows import _Window, _WindowNeedsParams
 
 __all__ = ["check_COLA", "check_NOLA", "coherence", "csd", "istft", "lombscargle", "periodogram", "spectrogram", "stft", "welch"]
@@ -214,13 +214,13 @@ def istft(
 
 #
 def coherence(
-    x: Untyped,
-    y: Untyped,
-    fs: float = 1.0,
-    window: str = "hann",
-    nperseg: int | None = None,
-    noverlap: int | None = None,
-    nfft: int | None = None,
-    detrend: str | Literal[False] | UntypedCallable = "constant",
-    axis: int = -1,
-) -> Untyped: ...
+    x: _ArrayLikeComplex_co,
+    y: _ArrayLikeComplex_co,
+    fs: AnyReal = 1.0,
+    window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
+    nperseg: AnyInt | None = None,
+    noverlap: AnyInt | None = None,
+    nfft: AnyInt | None = None,
+    detrend: _Detrend = "constant",
+    axis: op.CanIndex = -1,
+) -> tuple[_Array_f8, _ArrayReal]: ...

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -11,35 +11,46 @@ from scipy.signal.windows._windows import _Window, _WindowNeedsParams
 
 __all__ = ["check_COLA", "check_NOLA", "coherence", "csd", "istft", "lombscargle", "periodogram", "spectrogram", "stft", "welch"]
 
+_Array_f8_1d: TypeAlias = np.ndarray[tuple[int], np.dtype[np.float64]]
+
 _GetWindowArgument: TypeAlias = _Window | tuple[_Window | _WindowNeedsParams, Unpack[tuple[object, ...]]]
 _Detrend: TypeAlias = Literal["literal", "constant", False] | Callable[[npt.NDArray[np.generic]], npt.NDArray[np.generic]]
 _Scaling: TypeAlias = Literal["density", "spectrum"]
 _Average: TypeAlias = Literal["mean", "median"]
 
-def lombscargle(x: Untyped, y: Untyped, freqs: Untyped, precenter: bool = False, normalize: bool = False) -> Untyped: ...
+# NOTE(pavyamsiri): This function was actually recently updated, adding new arguments and return types.
+def lombscargle(
+    x: _ArrayLikeFloat_co,
+    y: _ArrayLikeFloat_co,
+    freqs: _ArrayLikeFloat_co,
+    precenter: op.CanBool = False,
+    normalize: op.CanBool = False,
+) -> _Array_f8_1d: ...
+
+# NOTE(pavyamsiri): The docs don't allow `None` for `window` but the body does?
 def periodogram(
-    x: Untyped,
-    fs: float = 1.0,
-    window: str = "boxcar",
-    nfft: int | None = None,
-    detrend: str | Literal[False] | UntypedCallable = "constant",
-    return_onesided: bool = True,
-    scaling: str = "density",
-    axis: int = -1,
-) -> Untyped: ...
+    x: _ArrayLikeComplex_co,
+    fs: AnyReal = 1.0,
+    window: _GetWindowArgument | _ArrayLikeFloat_co | None = "boxcar",
+    nfft: AnyInt | None = None,
+    detrend: _Detrend = "constant",
+    return_onesided: op.CanBool = True,
+    scaling: _Scaling = "density",
+    axis: op.CanIndex = -1,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.floating[Any]]]: ...
 def welch(
-    x: Untyped,
-    fs: float = 1.0,
-    window: str = "hann",
-    nperseg: int | None = None,
-    noverlap: int | None = None,
-    nfft: int | None = None,
-    detrend: str | Literal[False] | UntypedCallable = "constant",
-    return_onesided: bool = True,
-    scaling: str = "density",
-    axis: int = -1,
-    average: str = "mean",
-) -> Untyped: ...
+    x: _ArrayLikeComplex_co,
+    fs: AnyReal = 1.0,
+    window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
+    nperseg: AnyInt | None = None,
+    noverlap: AnyInt | None = None,
+    nfft: AnyInt | None = None,
+    detrend: _Detrend = "constant",
+    return_onesided: op.CanBool = True,
+    scaling: _Scaling = "density",
+    axis: op.CanIndex = -1,
+    average: _Average = "mean",
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.floating[Any]]]: ...
 def csd(
     x: _ArrayLikeComplex_co,
     y: _ArrayLikeComplex_co,

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -128,7 +128,7 @@ def check_NOLA(
     nperseg: AnyInt,
     noverlap: AnyInt,
     tol: AnyReal = 1e-10,
-) -> np.bool: ...
+) -> np.bool_: ...
 def stft(
     x: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -1,14 +1,20 @@
-from typing import Literal, TypeAlias
+from collections.abc import Callable
+from typing import Any, Literal, TypeAlias
 from typing_extensions import Unpack
 
+import numpy as np
+import numpy.typing as npt
 import optype as op
-from numpy._typing import _ArrayLikeFloat_co
+from numpy._typing import _ArrayLikeComplex_co, _ArrayLikeFloat_co
 from scipy._typing import AnyInt, AnyReal, Untyped, UntypedCallable
 from scipy.signal.windows._windows import _Window, _WindowNeedsParams
 
 __all__ = ["check_COLA", "check_NOLA", "coherence", "csd", "istft", "lombscargle", "periodogram", "spectrogram", "stft", "welch"]
 
 _GetWindowArgument: TypeAlias = _Window | tuple[_Window | _WindowNeedsParams, Unpack[tuple[object, ...]]]
+_Detrend: TypeAlias = Literal["literal", "constant", False] | Callable[[npt.NDArray[np.generic]], npt.NDArray[np.generic]]
+_Scaling: TypeAlias = Literal["density", "spectrum"]
+_Average: TypeAlias = Literal["mean", "median"]
 
 def lombscargle(x: Untyped, y: Untyped, freqs: Untyped, precenter: bool = False, normalize: bool = False) -> Untyped: ...
 def periodogram(
@@ -35,19 +41,19 @@ def welch(
     average: str = "mean",
 ) -> Untyped: ...
 def csd(
-    x: Untyped,
-    y: Untyped,
-    fs: float = 1.0,
-    window: str = "hann",
-    nperseg: int | None = None,
-    noverlap: int | None = None,
-    nfft: int | None = None,
-    detrend: str | Literal[False] | UntypedCallable = "constant",
-    return_onesided: bool = True,
-    scaling: str = "density",
-    axis: int = -1,
-    average: str = "mean",
-) -> Untyped: ...
+    x: _ArrayLikeComplex_co,
+    y: _ArrayLikeComplex_co,
+    fs: AnyReal = 1.0,
+    window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
+    nperseg: AnyInt | None = None,
+    noverlap: AnyInt | None = None,
+    nfft: AnyInt | None = None,
+    detrend: _Detrend = "constant",
+    return_onesided: op.CanBool = True,
+    scaling: _Scaling = "density",
+    axis: op.CanIndex = -1,
+    average: _Average = "mean",
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.complexfloating[Any, Any]]]: ...
 def spectrogram(
     x: Untyped,
     fs: float = 1.0,

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -69,8 +69,8 @@ def csd(
 ) -> tuple[_Array_f8, _ArrayComplex]: ...
 
 #
-# non-complex mode (positional and keyword)
 @overload
+# non-complex mode (positional and keyword)
 def spectrogram(
     x: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -5,15 +5,15 @@ from typing_extensions import Unpack
 import numpy as np
 import numpy.typing as npt
 import optype as op
-from numpy._typing import _ArrayLikeComplex_co, _ArrayLikeFloat_co
+from numpy._typing import _ArrayLikeFloat_co, _ArrayLikeNumber_co
 from scipy._typing import AnyInt, AnyReal
-from scipy.signal.windows._windows import _Window, _WindowNeedsParams
+from .windows._windows import _Window, _WindowNeedsParams
 
 __all__ = ["check_COLA", "check_NOLA", "coherence", "csd", "istft", "lombscargle", "periodogram", "spectrogram", "stft", "welch"]
 
+_Array_f: TypeAlias = npt.NDArray[np.floating[Any]]
 _Array_f8: TypeAlias = npt.NDArray[np.float64]
 _Array_f8_1d: TypeAlias = np.ndarray[tuple[int], np.dtype[np.float64]]
-_ArrayReal: TypeAlias = npt.NDArray[np.floating[Any]]
 _ArrayComplex: TypeAlias = npt.NDArray[np.complexfloating[Any, Any]]
 
 _GetWindowArgument: TypeAlias = _Window | tuple[_Window | _WindowNeedsParams, Unpack[tuple[object, ...]]]
@@ -31,7 +31,7 @@ def lombscargle(
     normalize: op.CanBool = False,
 ) -> _Array_f8_1d: ...
 def periodogram(
-    x: _ArrayLikeComplex_co,
+    x: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
     window: _GetWindowArgument | _ArrayLikeFloat_co | None = "boxcar",
     nfft: AnyInt | None = None,
@@ -39,9 +39,9 @@ def periodogram(
     return_onesided: op.CanBool = True,
     scaling: _Scaling = "density",
     axis: op.CanIndex = -1,
-) -> tuple[_Array_f8, _ArrayReal]: ...
+) -> tuple[_Array_f8, _Array_f]: ...
 def welch(
-    x: _ArrayLikeComplex_co,
+    x: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
     window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
     nperseg: AnyInt | None = None,
@@ -52,10 +52,10 @@ def welch(
     scaling: _Scaling = "density",
     axis: op.CanIndex = -1,
     average: _Average = "mean",
-) -> tuple[_Array_f8, _ArrayReal]: ...
+) -> tuple[_Array_f8, _Array_f]: ...
 def csd(
-    x: _ArrayLikeComplex_co,
-    y: _ArrayLikeComplex_co,
+    x: _ArrayLikeNumber_co,
+    y: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
     window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
     nperseg: AnyInt | None = None,
@@ -69,9 +69,10 @@ def csd(
 ) -> tuple[_Array_f8, _ArrayComplex]: ...
 
 #
+# non-complex mode (positional and keyword)
 @overload
 def spectrogram(
-    x: npt.NDArray[np.generic],
+    x: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
     window: _GetWindowArgument | _ArrayLikeFloat_co = ("tukey", 0.25),
     nperseg: AnyInt | None = None,
@@ -82,12 +83,11 @@ def spectrogram(
     scaling: _Scaling = "density",
     axis: op.CanIndex = -1,
     mode: Literal["psd", "magnitude", "angle", "phase"] = "psd",
-) -> tuple[_Array_f8, _Array_f8, _ArrayReal]: ...
-
-# complex mode (positional)
+) -> tuple[_Array_f8, _Array_f8, _Array_f]: ...
 @overload
+# complex mode (positional)
 def spectrogram(
-    x: npt.NDArray[np.generic],
+    x: _ArrayLikeNumber_co,
     fs: AnyReal,
     window: _GetWindowArgument | _ArrayLikeFloat_co,
     nperseg: AnyInt | None,
@@ -99,12 +99,10 @@ def spectrogram(
     axis: op.CanIndex,
     mode: Literal["complex"],
 ) -> tuple[_Array_f8, _Array_f8, _ArrayComplex]: ...
-
-# complex mode (keyword)
-
 @overload
+# complex mode (keyword)
 def spectrogram(
-    x: npt.NDArray[np.generic],
+    x: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
     window: _GetWindowArgument | _ArrayLikeFloat_co = ("tukey", 0.25),
     nperseg: AnyInt | None = None,
@@ -124,15 +122,15 @@ def check_COLA(
     nperseg: AnyInt,
     noverlap: AnyInt,
     tol: AnyReal = 1e-10,
-) -> bool: ...
+) -> np.bool: ...
 def check_NOLA(
     window: _GetWindowArgument | _ArrayLikeFloat_co,
     nperseg: AnyInt,
     noverlap: AnyInt,
     tol: AnyReal = 1e-10,
-) -> bool: ...
+) -> np.bool: ...
 def stft(
-    x: _ArrayLikeComplex_co,
+    x: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
     window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
     nperseg: AnyInt = 256,
@@ -146,49 +144,48 @@ def stft(
     scaling: _LegacyScaling = "spectrum",
 ) -> tuple[_Array_f8, _Array_f8, _ArrayComplex]: ...
 
-# input_onesided is `True`
+#
 @overload
+# input_onesided is `True`
 def istft(
-    Zxx: _ArrayLikeComplex_co,
+    Zxx: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
     window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
     nperseg: AnyInt | None = None,
     noverlap: AnyInt | None = None,
     nfft: AnyInt | None = None,
-    input_onesided: Literal[True] = True,
+    input_onesided: Literal[True, 1] = True,
     boundary: op.CanBool = True,
     time_axis: op.CanIndex = -1,
     freq_axis: op.CanIndex = -2,
     scaling: _LegacyScaling = "spectrum",
-) -> tuple[_Array_f8, _ArrayReal]: ...
-
-# input_onesided is `False` (positional)
+) -> tuple[_Array_f8, _Array_f]: ...
 @overload
+# input_onesided is `False` (positional)
 def istft(
-    Zxx: _ArrayLikeComplex_co,
+    Zxx: _ArrayLikeNumber_co,
     fs: AnyReal,
     window: _GetWindowArgument | _ArrayLikeFloat_co,
     nperseg: AnyInt | None,
     noverlap: AnyInt | None,
     nfft: AnyInt | None,
-    input_onesided: Literal[False],
+    input_onesided: Literal[False, 0],
     boundary: op.CanBool = True,
     time_axis: op.CanIndex = -1,
     freq_axis: op.CanIndex = -2,
     scaling: _LegacyScaling = "spectrum",
 ) -> tuple[_Array_f8, _ArrayComplex]: ...
-
-# input_onesided is `False` (keyword)
 @overload
+# input_onesided is `False` (keyword)
 def istft(
-    Zxx: _ArrayLikeComplex_co,
+    Zxx: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
     window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
     nperseg: AnyInt | None = None,
     noverlap: AnyInt | None = None,
     nfft: AnyInt | None = None,
     *,
-    input_onesided: Literal[False],
+    input_onesided: Literal[False, 0],
     boundary: op.CanBool = True,
     time_axis: op.CanIndex = -1,
     freq_axis: op.CanIndex = -2,
@@ -197,8 +194,8 @@ def istft(
 
 #
 def coherence(
-    x: _ArrayLikeComplex_co,
-    y: _ArrayLikeComplex_co,
+    x: _ArrayLikeNumber_co,
+    y: _ArrayLikeNumber_co,
     fs: AnyReal = 1.0,
     window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
     nperseg: AnyInt | None = None,
@@ -206,4 +203,4 @@ def coherence(
     nfft: AnyInt | None = None,
     detrend: _Detrend = "constant",
     axis: op.CanIndex = -1,
-) -> tuple[_Array_f8, _ArrayReal]: ...
+) -> tuple[_Array_f8, _Array_f]: ...

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -122,7 +122,7 @@ def check_COLA(
     nperseg: AnyInt,
     noverlap: AnyInt,
     tol: AnyReal = 1e-10,
-) -> np.bool: ...
+) -> np.bool_: ...
 def check_NOLA(
     window: _GetWindowArgument | _ArrayLikeFloat_co,
     nperseg: AnyInt,

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -19,7 +19,9 @@ _ArrayComplex: TypeAlias = npt.NDArray[np.complexfloating[Any, Any]]
 _GetWindowArgument: TypeAlias = _Window | tuple[_Window | _WindowNeedsParams, Unpack[tuple[object, ...]]]
 _Detrend: TypeAlias = Literal["literal", "constant", False] | Callable[[npt.NDArray[np.generic]], npt.NDArray[np.generic]]
 _Scaling: TypeAlias = Literal["density", "spectrum"]
+_LegacyScaling: TypeAlias = Literal["psd", "spectrum"]
 _Average: TypeAlias = Literal["mean", "median"]
+_Boundary: TypeAlias = Literal["even", "odd", "constant", "zeros"] | None
 
 # NOTE(pavyamsiri): This function was actually recently updated, adding new arguments and return types.
 def lombscargle(
@@ -133,32 +135,84 @@ def check_NOLA(
     tol: AnyReal = 1e-10,
 ) -> bool: ...
 def stft(
-    x: Untyped,
-    fs: float = 1.0,
-    window: str = "hann",
-    nperseg: int = 256,
-    noverlap: int | None = None,
-    nfft: int | None = None,
-    detrend: bool = False,
-    return_onesided: bool = True,
-    boundary: str = "zeros",
-    padded: bool = True,
-    axis: int = -1,
-    scaling: str = "spectrum",
-) -> Untyped: ...
+    x: _ArrayLikeComplex_co,
+    fs: AnyReal = 1.0,
+    window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
+    nperseg: AnyInt = 256,
+    noverlap: AnyInt | None = None,
+    nfft: AnyInt | None = None,
+    detrend: _Detrend = False,
+    return_onesided: op.CanBool = True,
+    boundary: _Boundary = "zeros",
+    padded: op.CanBool = True,
+    axis: op.CanIndex = -1,
+    scaling: _LegacyScaling = "spectrum",
+) -> tuple[_Array_f8, _Array_f8, _ArrayComplex]: ...
+
+# def istft(
+#     Zxx: _ArrayLikeComplex_co,
+#     fs: AnyReal = 1.0,
+#     window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
+#     nperseg: AnyInt | None = None,
+#     noverlap: AnyInt | None = None,
+#     nfft: AnyInt | None = None,
+#     input_onesided: op.CanBool = True,
+#     boundary: op.CanBool = True,
+#     time_axis: op.CanIndex = -1,
+#     freq_axis: op.CanIndex = -2,
+#     scaling: _LegacyScaling = "spectrum",
+# ) -> tuple[_Array_f8]: ...
+
+# input_onesided is `True`
+@overload
 def istft(
-    Zxx: Untyped,
-    fs: float = 1.0,
-    window: str = "hann",
-    nperseg: int | None = None,
-    noverlap: int | None = None,
-    nfft: int | None = None,
-    input_onesided: bool = True,
-    boundary: bool = True,
-    time_axis: int = -1,
-    freq_axis: int = -2,
-    scaling: str = "spectrum",
-) -> Untyped: ...
+    Zxx: _ArrayLikeComplex_co,
+    fs: AnyReal = 1.0,
+    window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
+    nperseg: AnyInt | None = None,
+    noverlap: AnyInt | None = None,
+    nfft: AnyInt | None = None,
+    input_onesided: Literal[True] = True,
+    boundary: op.CanBool = True,
+    time_axis: op.CanIndex = -1,
+    freq_axis: op.CanIndex = -2,
+    scaling: _LegacyScaling = "spectrum",
+) -> tuple[_Array_f8, _ArrayReal]: ...
+
+# input_onesided is `False` (positional)
+@overload
+def istft(
+    Zxx: _ArrayLikeComplex_co,
+    fs: AnyReal,
+    window: _GetWindowArgument | _ArrayLikeFloat_co,
+    nperseg: AnyInt | None,
+    noverlap: AnyInt | None,
+    nfft: AnyInt | None,
+    input_onesided: Literal[False],
+    boundary: op.CanBool = True,
+    time_axis: op.CanIndex = -1,
+    freq_axis: op.CanIndex = -2,
+    scaling: _LegacyScaling = "spectrum",
+) -> tuple[_Array_f8, _ArrayComplex]: ...
+
+# input_onesided is `False` (keyword)
+@overload
+def istft(
+    Zxx: _ArrayLikeComplex_co,
+    fs: AnyReal = 1.0,
+    window: _GetWindowArgument | _ArrayLikeFloat_co = "hann",
+    nperseg: AnyInt | None = None,
+    noverlap: AnyInt | None = None,
+    nfft: AnyInt | None = None,
+    *,
+    input_onesided: Literal[False],
+    boundary: op.CanBool = True,
+    time_axis: op.CanIndex = -1,
+    freq_axis: op.CanIndex = -2,
+    scaling: _LegacyScaling = "spectrum",
+) -> tuple[_Array_f8, _ArrayComplex]: ...
+
+#
 def coherence(
     x: Untyped,
     y: Untyped,

--- a/tests/signal/test_spectral.pyi
+++ b/tests/signal/test_spectral.pyi
@@ -1,0 +1,22 @@
+from typing import Any, TypeAlias
+from typing_extensions import assert_type
+
+import numpy as np
+import numpy.typing as npt
+from scipy.signal import spectrogram
+
+_Array_f8: TypeAlias = npt.NDArray[np.float64]
+_ArrayReal: TypeAlias = npt.NDArray[np.floating[Any]]
+_ArrayComplex: TypeAlias = npt.NDArray[np.complexfloating[Any, Any]]
+
+# test spectrogram function overloads
+assert_type(spectrogram(np.linspace(200, 300, 256)), tuple[_Array_f8, _Array_f8, _ArrayReal])
+assert_type(spectrogram(np.linspace(200, 300, 256), mode="psd"), tuple[_Array_f8, _Array_f8, _ArrayReal])
+assert_type(spectrogram(np.linspace(200, 300, 256), mode="magnitude"), tuple[_Array_f8, _Array_f8, _ArrayReal])
+assert_type(spectrogram(np.linspace(200, 300, 256), mode="angle"), tuple[_Array_f8, _Array_f8, _ArrayReal])
+assert_type(spectrogram(np.linspace(200, 300, 256), mode="phase"), tuple[_Array_f8, _Array_f8, _ArrayReal])
+assert_type(spectrogram(np.linspace(200, 300, 256), mode="complex"), tuple[_Array_f8, _Array_f8, _ArrayComplex])
+assert_type(
+    spectrogram(np.linspace(200, 300, 256), 1.0, ("tukey", 2.5), None, None, None, "constant", True, "density", -1, "complex"),
+    tuple[_Array_f8, _Array_f8, _ArrayComplex],
+)

--- a/tests/signal/test_spectral.pyi
+++ b/tests/signal/test_spectral.pyi
@@ -3,7 +3,7 @@ from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt
-from scipy.signal import spectrogram
+from scipy.signal import istft, spectrogram
 
 _Array_f8: TypeAlias = npt.NDArray[np.float64]
 _ArrayReal: TypeAlias = npt.NDArray[np.floating[Any]]
@@ -19,4 +19,47 @@ assert_type(spectrogram(np.linspace(200, 300, 256), mode="complex"), tuple[_Arra
 assert_type(
     spectrogram(np.linspace(200, 300, 256), 1.0, ("tukey", 2.5), None, None, None, "constant", True, "density", -1, "complex"),
     tuple[_Array_f8, _Array_f8, _ArrayComplex],
+)
+
+# test isft function overloads
+assert_type(istft(np.ones((129, 100), dtype=np.complex128)), tuple[_Array_f8, _ArrayReal])
+assert_type(istft(np.ones((129, 100), dtype=np.complex128), input_onesided=True), tuple[_Array_f8, _ArrayReal])
+assert_type(istft(np.ones((129, 100), dtype=np.complex128), 1.0, "hann", 256, 128, 256, False), tuple[_Array_f8, _ArrayComplex])
+assert_type(
+    istft(
+        np.ones((129, 100), dtype=np.complex128), input_onesided=False, fs=1.0, window="hann", nperseg=256, noverlap=128, nfft=256
+    ),
+    tuple[_Array_f8, _ArrayComplex],
+)
+assert_type(
+    istft(
+        np.ones((129, 100), dtype=np.complex128),
+        fs=2.0,
+        window=("tukey", 0.25),
+        nperseg=256,
+        noverlap=128,
+        nfft=256,
+        input_onesided=True,
+        boundary=False,
+        time_axis=-1,
+        freq_axis=0,
+        scaling="spectrum",
+    ),
+    tuple[_Array_f8, _ArrayReal],
+)
+assert_type(
+    istft(
+        np.ones((129, 100), dtype=np.complex128),
+        fs=2.0,
+        window=("tukey", 0.25),
+        nperseg=256,
+        noverlap=128,
+        nfft=256,
+        input_onesided=False,
+        boundary=False,
+        time_axis=0,
+        freq_axis=1,
+        scaling="spectrum",
+    ),
+    tuple[_Array_f8, _ArrayComplex],
 )

--- a/tests/signal/test_spectral.pyi
+++ b/tests/signal/test_spectral.pyi
@@ -7,8 +7,8 @@ import optype.numpy as onpt
 from scipy.signal import istft, spectrogram
 
 _Array_f8: TypeAlias = npt.NDArray[np.float64]
-_ArrayFloat: TypeAlias = npt.NDArray[np.float32 | np.float64 | np.float128]
-_ArrayComplex: TypeAlias = npt.NDArray[np.complex64 | np.complex128 | np.complex256]
+_ArrayFloat: TypeAlias = npt.NDArray[np.float32 | np.float64 | np.longdouble]
+_ArrayComplex: TypeAlias = npt.NDArray[np.complex64 | np.complex128 | np.clongdouble]
 
 array_f8_1d: onpt.Array[tuple[Literal[256]], np.float64]
 array_c16_1d: onpt.Array[tuple[Literal[256]], np.complex128]

--- a/tests/signal/test_spectral.pyi
+++ b/tests/signal/test_spectral.pyi
@@ -1,39 +1,39 @@
-from typing import Any, TypeAlias
+from typing import Literal, TypeAlias
 from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt
+import optype.numpy as onpt
 from scipy.signal import istft, spectrogram
 
 _Array_f8: TypeAlias = npt.NDArray[np.float64]
-_ArrayReal: TypeAlias = npt.NDArray[np.floating[Any]]
-_ArrayComplex: TypeAlias = npt.NDArray[np.complexfloating[Any, Any]]
+_ArrayFloat: TypeAlias = npt.NDArray[np.float32 | np.float64 | np.float128]
+_ArrayComplex: TypeAlias = npt.NDArray[np.complex64 | np.complex128 | np.complex256]
+
+array_f8_1d: onpt.Array[tuple[Literal[256]], np.float64]
+array_c16_1d: onpt.Array[tuple[Literal[256]], np.complex128]
+spectrogram_mode_real: Literal["psd", "magnitude", "angle", "phase"]
 
 # test spectrogram function overloads
-assert_type(spectrogram(np.linspace(200, 300, 256)), tuple[_Array_f8, _Array_f8, _ArrayReal])
-assert_type(spectrogram(np.linspace(200, 300, 256), mode="psd"), tuple[_Array_f8, _Array_f8, _ArrayReal])
-assert_type(spectrogram(np.linspace(200, 300, 256), mode="magnitude"), tuple[_Array_f8, _Array_f8, _ArrayReal])
-assert_type(spectrogram(np.linspace(200, 300, 256), mode="angle"), tuple[_Array_f8, _Array_f8, _ArrayReal])
-assert_type(spectrogram(np.linspace(200, 300, 256), mode="phase"), tuple[_Array_f8, _Array_f8, _ArrayReal])
-assert_type(spectrogram(np.linspace(200, 300, 256), mode="complex"), tuple[_Array_f8, _Array_f8, _ArrayComplex])
+assert_type(spectrogram(array_f8_1d), tuple[_Array_f8, _Array_f8, _ArrayFloat])
+assert_type(spectrogram(array_f8_1d, mode=spectrogram_mode_real), tuple[_Array_f8, _Array_f8, _ArrayFloat])
+assert_type(spectrogram(array_f8_1d, mode="complex"), tuple[_Array_f8, _Array_f8, _ArrayComplex])
 assert_type(
-    spectrogram(np.linspace(200, 300, 256), 1.0, ("tukey", 2.5), None, None, None, "constant", True, "density", -1, "complex"),
+    spectrogram(array_f8_1d, 1.0, ("tukey", 2.5), None, None, None, "constant", True, "density", -1, "complex"),
     tuple[_Array_f8, _Array_f8, _ArrayComplex],
 )
 
 # test isft function overloads
-assert_type(istft(np.ones((129, 100), dtype=np.complex128)), tuple[_Array_f8, _ArrayReal])
-assert_type(istft(np.ones((129, 100), dtype=np.complex128), input_onesided=True), tuple[_Array_f8, _ArrayReal])
-assert_type(istft(np.ones((129, 100), dtype=np.complex128), 1.0, "hann", 256, 128, 256, False), tuple[_Array_f8, _ArrayComplex])
+assert_type(istft(array_c16_1d), tuple[_Array_f8, _ArrayFloat])
+assert_type(istft(array_c16_1d, input_onesided=True), tuple[_Array_f8, _ArrayFloat])
+assert_type(istft(array_c16_1d, 1.0, "hann", 256, 128, 256, False), tuple[_Array_f8, _ArrayComplex])
 assert_type(
-    istft(
-        np.ones((129, 100), dtype=np.complex128), input_onesided=False, fs=1.0, window="hann", nperseg=256, noverlap=128, nfft=256
-    ),
+    istft(array_c16_1d, input_onesided=False, fs=1.0, window="hann", nperseg=256, noverlap=128, nfft=256),
     tuple[_Array_f8, _ArrayComplex],
 )
 assert_type(
     istft(
-        np.ones((129, 100), dtype=np.complex128),
+        array_c16_1d,
         fs=2.0,
         window=("tukey", 0.25),
         nperseg=256,
@@ -45,11 +45,11 @@ assert_type(
         freq_axis=0,
         scaling="spectrum",
     ),
-    tuple[_Array_f8, _ArrayReal],
+    tuple[_Array_f8, _ArrayFloat],
 )
 assert_type(
     istft(
-        np.ones((129, 100), dtype=np.complex128),
+        array_c16_1d,
         fs=2.0,
         window=("tukey", 0.25),
         nperseg=256,


### PR DESCRIPTION
Contributes to completing #99.

I added type stubs to the stub file `signal/_spectral_py.pyi` and tests for the function overloads I added.

## Caveats

I discovered that the function `lombscargle` was recently updated to include new parameters which also expands the possible return types (see PR scipy/scipy#21277). It also adds inline type stubs which might be an issue.

I did not type stub against this new version though because I think it is still in the dev branch and is not part of a release.

Also I saw that the function `periodogram`'s docs don't specify that `None` is allowed for the argument `window` but the body explicitly checks for `None`. Therefore I allowed `None` to be passed in as well. This is a bit annoying because the type annotation is no longer consistent with other `window` arguments in other functions.

I could have perhaps used more shaped typing but its a bit hard to verify because the functions are a bit complex, so I just left things as any shape.

