### PR TITLE
`optimize`: complete `_constraints` and `_trustregion_constr.*`

### DIFF
--- a/scipy-stubs/optimize/_constraints.pyi
+++ b/scipy-stubs/optimize/_constraints.pyi
@@ -1,58 +1,103 @@
-from scipy._typing import Untyped, UntypedCallable
+from collections.abc import Callable, Iterable
+from typing import Concatenate, Final, Literal, TypeAlias, TypedDict, type_check_only
+from typing_extensions import NotRequired, TypeVar
 
-class NonlinearConstraint:
-    fun: UntypedCallable
-    lb: Untyped
-    ub: Untyped
-    finite_diff_rel_step: Untyped
-    finite_diff_jac_sparsity: Untyped
-    jac: Untyped
-    hess: Untyped
-    keep_feasible: Untyped
+import numpy as np
+import optype as op
+import optype.numpy as onp
+from scipy.optimize._differentiable_functions import LinearVectorFunction, VectorFunction
+from scipy.optimize._hessian_update_strategy import HessianUpdateStrategy
+from scipy.sparse import sparray, spmatrix
+from scipy.sparse.linalg import LinearOperator
+
+_T = TypeVar("_T")
+_ShapeT_co = TypeVar("_ShapeT_co", bound=onp.AtLeast1D, default=onp.AtLeast1D, covariant=True)
+_SCT = TypeVar("_SCT", bound=np.generic, default=np.float64)
+
+_Tuple2: TypeAlias = tuple[_T, _T]
+_Sparse: TypeAlias = sparray | spmatrix
+_Vector: TypeAlias = onp.Array1D[_SCT]
+_Matrix: TypeAlias = onp.Array2D[_SCT] | _Sparse
+
+_MethodJac: TypeAlias = Literal["2-point", "3-point", "cs"]
+
+@type_check_only
+class _OldConstraint(TypedDict):
+    type: Literal["eq", "ineq"]
+    fun: Callable[Concatenate[_Vector, ...], onp.ToFloat1D]
+    jac: NotRequired[Callable[Concatenate[_Vector, ...], onp.ToFloat2D | _Sparse]]
+    args: NotRequired[tuple[object, ...]]
+
+@type_check_only
+class _BaseConstraint:
+    keep_feasible: Final[_Vector[np.bool_]]
+
+@type_check_only
+class _Constraint(_BaseConstraint):
+    lb: Final[_Vector]
+    ub: Final[_Vector]
+
+###
+
+class Bounds(_Constraint):
     def __init__(
         self,
         /,
-        fun: UntypedCallable,
-        lb: Untyped,
-        ub: Untyped,
-        jac: str = "2-point",
-        hess: Untyped = ...,
-        keep_feasible: bool = False,
-        finite_diff_rel_step: Untyped | None = None,
-        finite_diff_jac_sparsity: Untyped | None = None,
+        lb: onp.ToFloat | onp.ToFloat1D = ...,
+        ub: onp.ToFloat | onp.ToFloat1D = ...,
+        keep_feasible: onp.ToBool | onp.ToBool1D = False,
     ) -> None: ...
+    def residual(self, /, x: onp.ToFloat1D) -> _Tuple2[onp.Array[_ShapeT_co, np.float64]]: ...
 
-class LinearConstraint:
-    A: Untyped
-    lb: Untyped
-    ub: Untyped
-    keep_feasible: Untyped
-    def __init__(self, /, A: Untyped, lb: Untyped = ..., ub: Untyped = ..., keep_feasible: bool = False) -> None: ...
-    def residual(self, /, x: Untyped) -> Untyped: ...
+class LinearConstraint(_Constraint):
+    A: Final[_Matrix]
 
-class Bounds:
-    lb: Untyped
-    ub: Untyped
-    keep_feasible: Untyped
-    def __init__(self, /, lb: Untyped = ..., ub: Untyped = ..., keep_feasible: bool = False) -> None: ...
-    def residual(self, /, x: Untyped) -> Untyped: ...
-
-class PreparedConstraint:
-    fun: Untyped
-    bounds: Untyped
-    keep_feasible: Untyped
     def __init__(
         self,
         /,
-        constraint: Untyped,
-        x0: Untyped,
-        sparse_jacobian: Untyped | None = None,
-        finite_diff_bounds: Untyped = ...,
+        A: onp.ToFloat2D | _Sparse,
+        lb: onp.ToFloat | onp.ToFloat1D = ...,
+        ub: onp.ToFloat | onp.ToFloat1D = ...,
+        keep_feasible: onp.ToBool | onp.ToBool1D = False,
     ) -> None: ...
-    def violation(self, x: Untyped) -> Untyped: ...
+    def residual(self, /, x: onp.ToFloat1D) -> _Tuple2[_Vector]: ...
 
-def new_bounds_to_old(lb: Untyped, ub: Untyped, n: Untyped) -> Untyped: ...
-def old_bound_to_new(bounds: Untyped) -> Untyped: ...
-def strict_bounds(lb: Untyped, ub: Untyped, keep_feasible: Untyped, n_vars: Untyped) -> Untyped: ...
-def new_constraint_to_old(con: Untyped, x0: Untyped) -> Untyped: ...
-def old_constraint_to_new(ic: Untyped, con: Untyped) -> Untyped: ...
+class NonlinearConstraint(_Constraint):
+    fun: Final[Callable[[_Vector], onp.ToFloat1D]]
+    finite_diff_rel_step: Final[onp.ToFloat | onp.ToFloat1D | None]
+    finite_diff_jac_sparsity: Final[onp.ToFloat2D | _Sparse | None]
+    jac: Final[Callable[[_Vector], onp.ToFloat2D | _Sparse] | _MethodJac]
+    hess: Final[Callable[[_Vector], onp.ToFloat2D | _Sparse | LinearOperator] | _MethodJac | HessianUpdateStrategy | None]
+
+    def __init__(
+        self,
+        /,
+        fun: Callable[[_Vector], onp.ToFloat1D],
+        lb: onp.ToFloat | onp.ToFloat1D,
+        ub: onp.ToFloat | onp.ToFloat1D,
+        jac: Callable[[_Vector], onp.ToFloat2D | _Sparse] | _MethodJac = "2-point",
+        hess: Callable[[_Vector], onp.ToFloat2D | _Sparse | LinearOperator] | _MethodJac | HessianUpdateStrategy | None = ...,
+        keep_feasible: onp.ToBool | onp.ToBool1D = False,
+        finite_diff_rel_step: onp.ToFloat | onp.ToFloat1D | None = None,
+        finite_diff_jac_sparsity: onp.ToFloat2D | _Sparse | None = None,
+    ) -> None: ...
+
+class PreparedConstraint(_BaseConstraint):
+    fun: Final[VectorFunction | LinearVectorFunction]
+    bounds: Final[_Tuple2[_Vector]]
+
+    def __init__(
+        self,
+        /,
+        constraint: _Constraint,
+        x0: onp.ToFloat1D,
+        sparse_jacobian: bool | None = None,
+        finite_diff_bounds: _Tuple2[onp.ToFloat | onp.ToFloat2D] = ...,
+    ) -> None: ...
+    def violation(self, /, x: onp.ToFloat1D) -> _Vector: ...
+
+def new_bounds_to_old(lb: onp.ToFloat1D, ub: onp.ToFloat1D, n: op.CanIndex) -> list[_Tuple2[float]]: ...
+def old_bound_to_new(bounds: Iterable[_Tuple2[float]]) -> _Tuple2[_Vector]: ...
+def strict_bounds(lb: onp.ToFloat1D, ub: onp.ToFloat1D, keep_feasible: onp.ToBool1D, n_vars: op.CanIndex) -> _Tuple2[_Vector]: ...
+def new_constraint_to_old(con: _BaseConstraint, x0: onp.ToFloatND) -> list[_OldConstraint]: ...
+def old_constraint_to_new(ic: int, con: _OldConstraint) -> NonlinearConstraint: ...

--- a/scipy-stubs/optimize/_trustregion_constr/canonical_constraint.pyi
+++ b/scipy-stubs/optimize/_trustregion_constr/canonical_constraint.pyi
@@ -1,14 +1,13 @@
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import TypeAlias, TypeVar
 from typing_extensions import Self
 
 import numpy as np
 import optype as op
 import optype.numpy as onp
-from scipy._typing import Untyped
 from scipy.optimize._constraints import PreparedConstraint
 from scipy.sparse import csr_matrix
-from scipy.sparse.linalg._interface import LinearOperator
+from scipy.sparse.linalg import LinearOperator
 
 _T = TypeVar("_T")
 _Tuple2: TypeAlias = tuple[_T, _T]
@@ -20,16 +19,17 @@ _FunHess: TypeAlias = Callable[
     _Tuple2[onp.Array2D[np.float64] | csr_matrix | LinearOperator],
 ]
 
-# tighter than `Iterable[PreparedConstraint]` ;)
-_PreparedConstraints: TypeAlias = op.CanIter[op.CanNext[CanonicalConstraint]]
+_PreparedConstraints: TypeAlias = Iterable[CanonicalConstraint]
 
 class CanonicalConstraint:
     n_eq: int
     n_ineq: int
-    fun: Untyped
-    jac: Untyped
-    hess: Untyped
-    keep_feasible: Untyped
+    fun: _FunConstr
+    jac: _FunJac
+    hess: _FunHess
+
+    keep_feasible: onp.Array1D[np.bool_]
+
     def __init__(
         self,
         /,

--- a/scipy-stubs/optimize/_trustregion_constr/equality_constrained_sqp.pyi
+++ b/scipy-stubs/optimize/_trustregion_constr/equality_constrained_sqp.pyi
@@ -1,31 +1,42 @@
-from collections.abc import Sequence
-from typing import Any, TypeVar
+from collections.abc import Callable
+from typing import Any, Literal, TypeVar
 
 import numpy as np
 import optype.numpy as onp
-from scipy._typing import Untyped, UntypedCallable
 from scipy.sparse import dia_matrix
 
 __all__ = ["equality_constrained_sqp"]
 
 _StateT = TypeVar("_StateT")
 
-def default_scaling(x: onp.CanArray1D | Sequence[onp.ToScalar]) -> dia_matrix: ...
+def default_scaling(x: onp.ToArray1D) -> dia_matrix: ...
 def equality_constrained_sqp(
-    fun_and_constr: Untyped,
-    grad_and_jac: Untyped,
-    lagr_hess: Untyped,
-    x0: onp.Array1D[np.floating[Any]],
-    fun0: Untyped,
-    grad0: Untyped,
-    constr0: Untyped,
-    jac0: Untyped,
-    stop_criteria: Untyped,
+    fun_and_constr: Callable[[onp.Array1D[np.float64]], tuple[float | np.floating[Any], onp.ToFloat1D]],
+    grad_and_jac: Callable[[onp.Array1D[np.float64]], tuple[onp.ToFloat1D, onp.ToFloat2D]],
+    lagr_hess: Callable[[onp.Array1D[np.float64], onp.Array1D[np.float64]], onp.ToFloat2D],
+    x0: onp.ToFloat1D,
+    fun0: onp.ToFloat,
+    grad0: onp.ToFloat1D,
+    constr0: onp.ToFloat1D,
+    jac0: onp.ToFloat2D,
+    stop_criteria: Callable[
+        [
+            _StateT,  # state
+            onp.Array1D[np.float64],  # x
+            bool,  # last_iteration_failed
+            np.float64,  # optimality
+            np.float64,  # const_violation
+            np.float64,  # trust_radius
+            np.float64,  # penalty
+            dict[str, int],  # cg_info
+        ],
+        onp.ToBool,
+    ],
     state: _StateT,
-    initial_penalty: Untyped,
-    initial_trust_radius: Untyped,
-    factorization_method: Untyped,
-    trust_lb: Untyped | None = None,
-    trust_ub: Untyped | None = None,
-    scaling: UntypedCallable = ...,
+    initial_penalty: onp.ToFloat,
+    initial_trust_radius: onp.ToFloat,
+    factorization_method: Literal["NormalEquation", "AugmentedSystem", "QRFactorization", "SVDFactorization"],
+    trust_lb: onp.Array1D[np.floating[Any]] | None = None,
+    trust_ub: onp.Array1D[np.floating[Any]] | None = None,
+    scaling: Callable[[onp.Array1D[np.float64]], dia_matrix] = ...,
 ) -> tuple[onp.Array1D[np.floating[Any]], _StateT]: ...

--- a/scipy-stubs/optimize/_trustregion_constr/minimize_trustregion_constr.pyi
+++ b/scipy-stubs/optimize/_trustregion_constr/minimize_trustregion_constr.pyi
@@ -1,108 +1,136 @@
-from typing import Final, Literal
+from collections.abc import Callable, Iterable
+from typing import Concatenate, Final, Literal, Protocol, TypeAlias, TypedDict, type_check_only
 
 import numpy as np
-import numpy.typing as npt
 import optype.numpy as onp
-from scipy._typing import Untyped, UntypedCallable
+from scipy.optimize._constraints import Bounds, LinearConstraint, NonlinearConstraint, PreparedConstraint
 from scipy.optimize._optimize import OptimizeResult as _OptimizeResult
-from scipy.sparse import spmatrix
+from scipy.sparse import sparray, spmatrix
 from scipy.sparse.linalg import LinearOperator
+from .canonical_constraint import CanonicalConstraint
+
+_StopCond: TypeAlias = Literal[0, 1, 2, 3, 4]
+
+_Float: TypeAlias = float | np.float64
+_Float1D: TypeAlias = onp.Array1D[np.float64]
+_Float2D: TypeAlias = onp.Array2D[np.float64]
+_FloatND: TypeAlias = onp.ArrayND[np.float64]
+_Sparse: TypeAlias = spmatrix | sparray
+_Matrix: TypeAlias = _Float2D | _Sparse
+
+_HessPFunc: TypeAlias = Callable[Concatenate[_Float1D, _Float1D, ...], _Float1D]
+_ObjectiveHessFunc: TypeAlias = Callable[[_Float1D], _Matrix]
+_ConstraintsHessFunc: TypeAlias = Callable[[_Float1D, _Float1D, _Float1D], _Matrix]
+
+@type_check_only
+class _CGInfo(TypedDict):
+    niter: int
+    stop_cond: _StopCond
+    hits_boundary: bool
+
+@type_check_only
+class _Objective(Protocol):
+    f: _Float
+    g: _Float1D
+    nfev: int
+    njev: int
+    nhev: int
 
 ###
 
 TERMINATION_MESSAGES: dict[Literal[0, 1, 2, 3], str]  # undocumented
 
 class OptimizeResult(_OptimizeResult):
-    x: onp.Array1D[np.float64]
-    optimality: float | np.float64
-    const_violation: float | np.float64
-    fun: float | np.float64
-    grad: onp.Array1D[np.float64]
-    lagrangian_grad: onp.Array1D[np.float64]
-    nit: int | np.intp
-    nfev: int | np.intp
-    njev: int | np.intp
-    nhev: int | np.intp
+    x: _Float1D
+    optimality: _Float
+    const_violation: _Float
+    fun: _Float
+    grad: _Float1D
+    lagrangian_grad: _Float1D
+    nit: int
+    nfev: int
+    njev: int
+    nhev: int
     cg_niter: int
     method: Literal["equality_constrained_sqp", "tr_interior_point"]
-    constr: list[float | np.float64]
-    jac: list[onp.Array2D[np.float64] | spmatrix]
-    v: list[onp.ArrayND[np.float64]]
+    constr: list[_Float]
+    jac: list[_Matrix]
+    v: list[_FloatND]
     constr_nfev: list[int]
     constr_njev: list[int]
     constr_nhev: list[int]
-    tr_radius: float | np.float64
-    constr_penalty: float | np.float64
-    barrier_tolerance: float | np.float64
-    barrier_parameter: float | np.float64
-    execution_time: float | np.float64
+    tr_radius: _Float
+    constr_penalty: _Float
+    barrier_tolerance: _Float
+    barrier_parameter: _Float
+    execution_time: _Float
     message: str
     status: Literal[0, 1, 2, 3]
-    cg_stop_cond: Literal[0, 1, 2, 3, 4]
+    cg_stop_cond: _StopCond
 
 # undocumented
 class HessianLinearOperator:
     n: Final[int]
-    hessp: Final[UntypedCallable]
+    hessp: Final[_HessPFunc]
 
-    def __init__(self, /, hessp: UntypedCallable, n: int) -> None: ...
-    def __call__(self, /, x: Untyped, *args: object) -> LinearOperator: ...
+    def __init__(self, /, hessp: _HessPFunc, n: int) -> None: ...
+    def __call__(self, /, x: _Float1D, *args: object) -> LinearOperator: ...
 
 # undocumented
 class LagrangianHessian:
     n: Final[int]
-    objective_hess: Final[UntypedCallable]
-    constraints_hess: Final[UntypedCallable]
+    objective_hess: Final[_ObjectiveHessFunc]
+    constraints_hess: Final[_ConstraintsHessFunc]
 
-    def __init__(self, /, n: int, objective_hess: UntypedCallable, constraints_hess: UntypedCallable) -> None: ...
-    def __call__(self, /, x: Untyped, v_eq: Untyped, v_ineq: Untyped) -> LinearOperator: ...
+    def __init__(self, /, n: int, objective_hess: _ObjectiveHessFunc, constraints_hess: _ConstraintsHessFunc) -> None: ...
+    def __call__(self, /, x: _Float1D, v_eq: _Float1D, v_ineq: _Float1D) -> LinearOperator: ...
 
 # undocumented
 def update_state_sqp(
-    state: Untyped,
-    x: Untyped,
-    last_iteration_failed: Untyped,
-    objective: Untyped,
-    prepared_constraints: Untyped,
-    start_time: Untyped,
-    tr_radius: Untyped,
-    constr_penalty: Untyped,
-    cg_info: Untyped,
-) -> Untyped: ...
+    state: OptimizeResult,
+    x: _Float1D,
+    last_iteration_failed: bool,
+    objective: _Objective,
+    prepared_constraints: Iterable[CanonicalConstraint | PreparedConstraint],
+    start_time: float,
+    tr_radius: _Float,
+    constr_penalty: _Float,
+    cg_info: _CGInfo,
+) -> OptimizeResult: ...
 
 # undocumented
 def update_state_ip(
-    state: Untyped,
-    x: Untyped,
-    last_iteration_failed: Untyped,
-    objective: Untyped,
-    prepared_constraints: Untyped,
-    start_time: Untyped,
-    tr_radius: Untyped,
-    constr_penalty: Untyped,
-    cg_info: Untyped,
-    barrier_parameter: Untyped,
-    barrier_tolerance: Untyped,
-) -> Untyped: ...
+    state: OptimizeResult,
+    x: _Float1D,
+    last_iteration_failed: bool,
+    objective: _Objective,
+    prepared_constraints: Iterable[CanonicalConstraint | PreparedConstraint],
+    start_time: float,
+    tr_radius: _Float,
+    constr_penalty: _Float,
+    cg_info: _CGInfo,
+    barrier_parameter: _Float,
+    barrier_tolerance: _Float,
+) -> OptimizeResult: ...
 
 #
 def _minimize_trustregion_constr(
-    fun: UntypedCallable,
-    x0: npt.ArrayLike,
+    fun: Callable[Concatenate[_Float1D, ...], _Float],
+    x0: onp.ToFloat1D,
     args: tuple[object, ...],
-    grad: Untyped,
-    hess: Untyped,
-    hessp: Untyped,
-    bounds: Untyped,
-    constraints: Untyped,
+    grad: Callable[Concatenate[_Float1D, ...], onp.ToFloat1D] | None,
+    hess: Callable[Concatenate[_Float1D, ...], onp.ToFloat2D | _Sparse | LinearOperator] | None,
+    hessp: _HessPFunc | None,
+    bounds: Bounds | None,
+    constraints: LinearConstraint | NonlinearConstraint | None,
     xtol: float = 1e-8,
     gtol: float = 1e-8,
     barrier_tol: float = 1e-8,
     sparse_jacobian: bool | None = None,
-    callback: UntypedCallable | None = None,
+    callback: Callable[[OptimizeResult], None] | None = None,
     maxiter: int = 1000,
     verbose: Literal[0, 1, 2] = 0,
-    finite_diff_rel_step: npt.ArrayLike | None = None,
+    finite_diff_rel_step: onp.ToFloat1D | None = None,
     initial_constr_penalty: float = 1.0,
     initial_tr_radius: float = 1.0,
     initial_barrier_parameter: float = 0.1,

--- a/scipy-stubs/optimize/_trustregion_constr/projections.pyi
+++ b/scipy-stubs/optimize/_trustregion_constr/projections.pyi
@@ -1,20 +1,73 @@
-from typing import Final
+from collections.abc import Callable
+from typing import Any, Final, Literal, TypeAlias
 
-from scipy._typing import Untyped
+import numpy as np
+import optype.numpy as onp
+from scipy.sparse import sparray, spmatrix
+from scipy.sparse.linalg import LinearOperator
 
 __all__ = ["orthogonality", "projections"]
 
+_ToMatrix: TypeAlias = onp.ToFloat2D | spmatrix | sparray
+
+_Projections: TypeAlias = tuple[
+    Callable[[onp.ToFloat1D], onp.ToFloat1D],
+    Callable[[onp.ToFloat1D], onp.ToFloat1D],
+    Callable[[onp.ToFloat1D], onp.ToFloat1D],
+]
+
+###
+
 sksparse_available: Final[bool] = ...
 
-def orthogonality(A: Untyped, g: Untyped) -> Untyped: ...
-def normal_equation_projections(A: Untyped, m: int, n: int, orth_tol: Untyped, max_refin: int, tol: float) -> Untyped: ...
-def augmented_system_projections(A: Untyped, m: int, n: int, orth_tol: Untyped, max_refin: int, tol: float) -> Untyped: ...
-def qr_factorization_projections(A: Untyped, m: int, n: int, orth_tol: Untyped, max_refin: int, tol: float) -> Untyped: ...
-def svd_factorization_projections(A: Untyped, m: int, n: int, orth_tol: Untyped, max_refin: int, tol: float) -> Untyped: ...
+# undocumented
+def orthogonality(A: _ToMatrix, g: onp.ToFloat1D) -> np.floating[Any]: ...
+
+# undocumented
+def normal_equation_projections(
+    A: _ToMatrix,
+    m: int,
+    n: int,
+    orth_tol: float | np.floating[Any],
+    max_refin: int,
+    tol: float,
+) -> _Projections: ...
+
+# undocumented
+def augmented_system_projections(
+    A: _ToMatrix,
+    m: int,
+    n: int,
+    orth_tol: float | np.floating[Any],
+    max_refin: int,
+    tol: float,
+) -> _Projections: ...
+
+# undocumented
+def qr_factorization_projections(
+    A: _ToMatrix,
+    m: int,
+    n: int,
+    orth_tol: float | np.floating[Any],
+    max_refin: int,
+    tol: float,
+) -> _Projections: ...
+
+# undocumented
+def svd_factorization_projections(
+    A: _ToMatrix,
+    m: int,
+    n: int,
+    orth_tol: float | np.floating[Any],
+    max_refin: int,
+    tol: float,
+) -> _Projections: ...
+
+#
 def projections(
-    A: Untyped,
-    method: Untyped | None = None,
-    orth_tol: float = 1e-12,
-    max_refin: int = 3,
-    tol: float = 1e-15,
-) -> Untyped: ...
+    A: _ToMatrix,
+    method: Literal["NormalEquation", "AugmentedSystem", "QRFactorization", "SVDFactorization"] | None = None,
+    orth_tol: float | np.floating[Any] = 1e-12,
+    max_refin: onp.ToJustInt = 3,
+    tol: float | np.floating[Any] = 1e-15,
+) -> tuple[LinearOperator, LinearOperator, LinearOperator]: ...

--- a/scipy-stubs/optimize/_trustregion_constr/tr_interior_point.pyi
+++ b/scipy-stubs/optimize/_trustregion_constr/tr_interior_point.pyi
@@ -1,96 +1,50 @@
-from scipy._typing import Untyped
+from collections.abc import Callable
+from typing import Any, Literal, TypeVar
+
+import numpy as np
+import optype.numpy as onp
 
 __all__ = ["tr_interior_point"]
 
-class BarrierSubproblem:
-    n_vars: Untyped
-    x0: Untyped
-    s0: Untyped
-    fun: Untyped
-    grad: Untyped
-    lagr_hess: Untyped
-    constr: Untyped
-    jac: Untyped
-    barrier_parameter: Untyped
-    tolerance: Untyped
-    n_eq: Untyped
-    n_ineq: Untyped
-    enforce_feasibility: Untyped
-    global_stop_criteria: Untyped
-    xtol: Untyped
-    fun0: Untyped
-    grad0: Untyped
-    constr0: Untyped
-    jac0: Untyped
-    terminate: bool
-    def __init__(
-        self,
-        x0: Untyped,
-        s0: Untyped,
-        fun: Untyped,
-        grad: Untyped,
-        lagr_hess: Untyped,
-        n_vars: Untyped,
-        n_ineq: Untyped,
-        n_eq: Untyped,
-        constr: Untyped,
-        jac: Untyped,
-        barrier_parameter: Untyped,
-        tolerance: Untyped,
-        enforce_feasibility: Untyped,
-        global_stop_criteria: Untyped,
-        xtol: Untyped,
-        fun0: Untyped,
-        grad0: Untyped,
-        constr_ineq0: Untyped,
-        jac_ineq0: Untyped,
-        constr_eq0: Untyped,
-        jac_eq0: Untyped,
-    ) -> None: ...
-    def update(self, barrier_parameter: Untyped, tolerance: Untyped) -> None: ...
-    def get_slack(self, z: Untyped) -> Untyped: ...
-    def get_variables(self, z: Untyped) -> Untyped: ...
-    def function_and_constraints(self, z: Untyped) -> Untyped: ...
-    def scaling(self, z: Untyped) -> Untyped: ...
-    def gradient_and_jacobian(self, z: Untyped) -> Untyped: ...
-    def lagrangian_hessian_x(self, z: Untyped, v: Untyped) -> Untyped: ...
-    def lagrangian_hessian_s(self, z: Untyped, v: Untyped) -> Untyped: ...
-    def lagrangian_hessian(self, z: Untyped, v: Untyped) -> Untyped: ...
-    def stop_criteria(
-        self,
-        state: Untyped,
-        z: Untyped,
-        last_iteration_failed: Untyped,
-        optimality: Untyped,
-        constr_violation: Untyped,
-        trust_radius: Untyped,
-        penalty: Untyped,
-        cg_info: Untyped,
-    ) -> Untyped: ...
+_StateT = TypeVar("_StateT")
+
+###
 
 def tr_interior_point(
-    fun: Untyped,
-    grad: Untyped,
-    lagr_hess: Untyped,
-    n_vars: Untyped,
-    n_ineq: Untyped,
-    n_eq: Untyped,
-    constr: Untyped,
-    jac: Untyped,
-    x0: Untyped,
-    fun0: Untyped,
-    grad0: Untyped,
-    constr_ineq0: Untyped,
-    jac_ineq0: Untyped,
-    constr_eq0: Untyped,
-    jac_eq0: Untyped,
-    stop_criteria: Untyped,
-    enforce_feasibility: Untyped,
-    xtol: Untyped,
-    state: Untyped,
-    initial_barrier_parameter: Untyped,
-    initial_tolerance: Untyped,
-    initial_penalty: Untyped,
-    initial_trust_radius: Untyped,
-    factorization_method: Untyped,
-) -> Untyped: ...
+    fun: Callable[[onp.Array1D[np.float64]], onp.ToFloat],
+    grad: Callable[[onp.Array1D[np.float64]], onp.ToFloat1D],
+    lagr_hess: Callable[[onp.Array1D[np.float64], onp.Array1D[np.float64]], onp.ToFloat2D],
+    n_vars: int,
+    n_ineq: int,
+    n_eq: int,
+    constr: Callable[[onp.Array1D[np.float64]], tuple[onp.ToFloat1D, onp.ToFloat1D]],
+    jac: Callable[[onp.Array1D[np.float64]], tuple[onp.ToFloat2D, onp.ToFloat2D]],
+    x0: onp.ToFloat1D,
+    fun0: onp.ToFloat,
+    grad0: onp.ToFloat1D,
+    constr_ineq0: onp.ArrayND[np.floating[Any]],
+    jac_ineq0: onp.ToArray2D,
+    constr_eq0: onp.ArrayND[np.floating[Any]],
+    jac_eq0: onp.ToArray2D,
+    stop_criteria: Callable[
+        [
+            _StateT,  # state
+            onp.Array1D[np.float64],  # x
+            bool,  # last_iteration_failed
+            np.float64,  # optimality
+            np.float64,  # const_violation
+            np.float64,  # trust_radius
+            np.float64,  # penalty
+            dict[str, int],  # cg_info
+        ],
+        onp.ToBool,
+    ],
+    enforce_feasibility: onp.ToArray1D,
+    xtol: float,
+    state: _StateT,
+    initial_barrier_parameter: float,
+    initial_tolerance: float,
+    initial_penalty: onp.ToFloat,
+    initial_trust_radius: onp.ToFloat,
+    factorization_method: Literal["NormalEquation", "AugmentedSystem", "QRFactorization", "SVDFactorization"],
+) -> tuple[onp.Array1D[np.floating[Any]], _StateT]: ...


### PR DESCRIPTION
This mostly affects the internal constraint-based machinery within `scipy.optimize`. The only affected public members are

- `Bounds`
- `LinearConstraint`
- `NonlinearConstraint`

225 `Untyped` annotations were resolved