### PR TITLE
`optimize`: complete the root-finding functions

### DIFF
--- a/scipy-stubs/optimize/_root.pyi
+++ b/scipy-stubs/optimize/_root.pyi
@@ -1,10 +1,11 @@
-from collections.abc import Mapping
-from typing import Any, Literal, TypeAlias, type_check_only
+from collections.abc import Callable, Mapping
+from typing import Any, Concatenate, Generic, Literal, TypeAlias, TypedDict, TypeVar, overload, type_check_only
 
 import numpy as np
 import optype.numpy as onp
-from scipy._typing import UntypedCallable
-from ._optimize import OptimizeResult
+from scipy.sparse.linalg import LinearOperator
+from ._nonlin import InverseJacobian
+from ._optimize import OptimizeResult as _OptimizeResult
 
 __all__ = ["root"]
 
@@ -21,22 +22,141 @@ _RootMethod: TypeAlias = Literal[
     "df-sane",
 ]
 
+_JacOptionsT = TypeVar("_JacOptionsT", bound=Mapping[str, object])
+
 @type_check_only
-class _OptimizeResult(OptimizeResult):
-    x: onp.ArrayND[np.number[Any]]
+class _RootOptionsHybr(TypedDict, total=False):
+    col_deriv: onp.ToBool
+    xtol: onp.ToFloat
+    maxffev: onp.ToJustInt
+    band: tuple[onp.ToJustInt, onp.ToJustInt]
+    eps: onp.ToFloat
+    factor: onp.ToFloat
+    diag: onp.ToFloat1D
+
+@type_check_only
+class _RootOptionsLM(TypedDict, total=False):
+    col_deriv: onp.ToBool
+    ftol: onp.ToFloat
+    xtol: onp.ToFloat
+    gtol: onp.ToFloat
+    maxiter: onp.ToJustInt
+    eps: onp.ToFloat
+    factor: onp.ToFloat
+    diag: onp.ToFloat1D
+
+@type_check_only
+class _RootOptionsJacBase(TypedDict, Generic[_JacOptionsT], total=False):
+    nit: onp.ToJustInt
+    disp: onp.ToBool
+    maxiter: onp.ToJustInt
+    ftol: onp.ToFloat
+    fatol: onp.ToFloat
+    xtol: onp.ToFloat
+    xatol: onp.ToFloat
+    tol_norm: Callable[[onp.Array1D[np.float64]], onp.ToFloat]
+    line_search: Literal["armijo", "wolfe"] | None
+    jac_options: _JacOptionsT
+
+@type_check_only
+class _JacOptionsBase(TypedDict, total=False):
+    alpha: onp.ToFloat
+
+@type_check_only
+class _JacOptionsBroyden(_JacOptionsBase, total=False):
+    reduction_method: Literal["restart", "simple", "svd"] | tuple[Literal["svd"], onp.ToJustInt]
+    max_rank: onp.ToJustInt
+
+@type_check_only
+class _JacOptionsAnderson(_JacOptionsBase, total=False):
+    M: onp.ToFloat
+    w0: onp.ToFloat
+
+@type_check_only
+class _JacOptionsExcitingMixing(_JacOptionsBase, total=False):
+    alphamax: onp.ToFloat
+
+@type_check_only
+class _JacOptionsKrylov(TypedDict, total=False):
+    rdiff: onp.ToFloat
+    method: Literal["lgmres", "gmres", "bicgstab", "cgs", "minres", "tfqmr"] | Callable[..., onp.ToFloatND]
+    inner_M: LinearOperator | InverseJacobian
+    inner_rtol: onp.ToFloat
+    inner_atol: onp.ToFloat
+    inner_maxiter: onp.ToJustInt
+    outer_k: onp.ToJustInt
+
+_RootOptionsBroyden: TypeAlias = _RootOptionsJacBase[_JacOptionsBroyden]
+_RootOptionsAnderson: TypeAlias = _RootOptionsJacBase[_JacOptionsAnderson]
+_RootOptionsLinearMixing: TypeAlias = _RootOptionsJacBase[_JacOptionsBase]
+_RootOptionsDiagBroyden: TypeAlias = _RootOptionsJacBase[_JacOptionsBase]
+_RootOptionsExcitingMixing: TypeAlias = _RootOptionsJacBase[_JacOptionsExcitingMixing]
+_RootOptionsKrylov: TypeAlias = _RootOptionsJacBase[_JacOptionsKrylov]
+
+@type_check_only
+class _RootOptionsDFSane(TypedDict, total=False):
+    ftol: onp.ToFloat
+    fatol: onp.ToFloat
+    fnorm: Callable[[onp.ArrayND[np.float64]], onp.ToFloat]
+    maxfev: onp.ToJustInt
+    disp: onp.ToBool
+    eta_strategy: Callable[[int, onp.ArrayND[np.float64], onp.ArrayND[np.float64]], onp.ToFloat1D]
+    sigma_eps: onp.ToFloat
+    sigma_0: onp.ToFloat
+    M: onp.ToJustInt
+    line_search: Literal["cruz", "cheng"]
+
+_RootOptions: TypeAlias = (
+    _RootOptionsHybr
+    | _RootOptionsLM
+    | _RootOptionsBroyden
+    | _RootOptionsAnderson
+    | _RootOptionsLinearMixing
+    | _RootOptionsDiagBroyden
+    | _RootOptionsExcitingMixing
+    | _RootOptionsKrylov
+    | _RootOptionsDFSane
+)
+
+###
+
+class OptimizeResult(_OptimizeResult):
+    x: onp.ArrayND[np.floating[Any]]
     success: bool
     message: str
     nfev: int
 
-###
-
+@overload  # `jac` not given (None), False, or a callable
 def root(
-    fun: UntypedCallable,
-    x0: onp.ArrayND[np.number[Any]],
+    fun: Callable[Concatenate[onp.ArrayND[np.float64], ...], onp.ToFloatND],
+    x0: onp.ToFloatND,
     args: tuple[object, ...] = (),
     method: _RootMethod = "hybr",
-    jac: bool | np.bool_ | UntypedCallable | None = None,
+    jac: Callable[Concatenate[onp.ArrayND[np.float64], ...], onp.ToFloatND] | Literal[False, 0] | None = None,
     tol: onp.ToFloat | None = None,
-    callback: UntypedCallable | None = None,
-    options: Mapping[str, object] | None = None,
+    callback: Callable[[onp.ArrayND[np.float64], onp.ArrayND[np.float64]], None] | None = None,
+    options: _RootOptions | None = None,
+) -> _OptimizeResult: ...
+@overload  # `jac` truthy (positional)
+def root(
+    fun: Callable[Concatenate[onp.ArrayND[np.float64], ...], tuple[onp.ToFloatND, onp.ToFloatND]],
+    x0: onp.ToFloatND,
+    args: tuple[object, ...],
+    method: _RootMethod,
+    jac: Literal[True, 1],
+    tol: onp.ToFloat | None = None,
+    callback: Callable[[onp.ArrayND[np.float64], onp.ArrayND[np.float64]], None] | None = None,
+    options: _RootOptions | None = None,
+) -> _OptimizeResult: ...
+@overload  # `jac` truthy (keyword)
+def root(
+    fun: Callable[Concatenate[onp.ArrayND[np.float64], ...], tuple[onp.ToFloatND, onp.ToFloatND]],
+    x0: onp.ToFloatND,
+    args: tuple[object, ...] = (),
+    method: _RootMethod = "hybr",
+    *,
+    jac: Literal[True, 1],
+    tol: onp.ToFloat | None = None,
+    callback: Callable[[onp.ArrayND[np.float64], onp.ArrayND[np.float64]], None] | None = None,
+    options: _RootOptions | None = None,
 ) -> _OptimizeResult: ...

--- a/scipy-stubs/optimize/_root_scalar.pyi
+++ b/scipy-stubs/optimize/_root_scalar.pyi
@@ -1,31 +1,178 @@
-from scipy._typing import Untyped
+from collections.abc import Callable, Mapping
+from typing import Concatenate, Final, Generic, Literal, TypeAlias, overload
+from typing_extensions import TypeVar
+
+import numpy as np
+import optype.numpy as onp
+from ._typing import MethodRootScalar
+from ._zeros_py import RootResults
 
 __all__ = ["root_scalar"]
 
-ROOT_SCALAR_METHODS: Untyped
+_Falsy: TypeAlias = Literal[False, 0]
+_Truthy: TypeAlias = Literal[True, 1]
 
-class MemoizeDer:
-    fun: Untyped
-    vals: Untyped
-    x: Untyped
+_ToFloat2: TypeAlias = tuple[onp.ToFloat, onp.ToFloat]
+_ToFloat3: TypeAlias = tuple[onp.ToFloat, onp.ToFloat, onp.ToFloat]
+
+_RT = TypeVar("_RT", bound=onp.ToFloat | _ToFloat2 | _ToFloat3)
+_RT2_co = TypeVar("_RT2_co", bound=_ToFloat2 | _ToFloat3, default=_ToFloat2 | _ToFloat3, covariant=True)
+
+_Fun: TypeAlias = Callable[Concatenate[float, ...], _RT] | Callable[Concatenate[np.float64, ...], _RT]
+_Fun1: TypeAlias = _Fun[onp.ToFloat]
+_Fun2: TypeAlias = _Fun[_ToFloat2]
+_Fun3: TypeAlias = _Fun[_ToFloat3]
+
+###
+
+ROOT_SCALAR_METHODS: Final[list[MethodRootScalar]] = ...
+
+class MemoizeDer(Generic[_RT2_co]):  # undocumented
+    fun: _Fun[_RT2_co]  # readonly
+    vals: _RT2_co | None
+    x: onp.ToFloat
     n_calls: int
-    def __init__(self, fun: Untyped) -> None: ...
-    def __call__(self, x: Untyped, *args: Untyped) -> Untyped: ...
-    def fprime(self, x: Untyped, *args: Untyped) -> Untyped: ...
-    def fprime2(self, x: Untyped, *args: Untyped) -> Untyped: ...
-    def ncalls(self) -> Untyped: ...
 
+    def __init__(self, /, fun: _Fun[_RT2_co]) -> None: ...
+    def __call__(self, /, x: onp.ToFloat, *args: object) -> onp.ToFloat: ...
+    def fprime(self, /, x: onp.ToFloat, *args: object) -> onp.ToFloat: ...
+    def fprime2(self: MemoizeDer[_ToFloat3], /, x: onp.ToFloat, *args: object) -> onp.ToFloat: ...
+    def ncalls(self, /) -> int: ...
+
+@overload  # bisect | brentq | brenth | ridder | toms748  (positional)
 def root_scalar(
-    f: Untyped,
-    args: Untyped = (),
-    method: Untyped | None = None,
-    bracket: Untyped | None = None,
-    fprime: Untyped | None = None,
-    fprime2: Untyped | None = None,
-    x0: Untyped | None = None,
-    x1: Untyped | None = None,
-    xtol: Untyped | None = None,
-    rtol: Untyped | None = None,
-    maxiter: Untyped | None = None,
-    options: Untyped | None = None,
-) -> Untyped: ...
+    f: _Fun1,
+    args: tuple[object, ...],
+    method: Literal["bisect", "brentq", "brenth", "ridder", "toms748"] | None,
+    bracket: tuple[onp.ToFloat, onp.ToFloat],
+    fprime: _Falsy | None = None,
+    fprime2: _Falsy | None = None,
+    x0: None = None,
+    x1: None = None,
+    xtol: onp.ToFloat | None = None,
+    rtol: onp.ToFloat | None = None,
+    maxiter: onp.ToJustInt | None = None,
+    options: Mapping[str, object] | None = None,
+) -> RootResults[float]: ...
+@overload  # bisect | brentq | brenth | ridder | toms748  (keyword)
+def root_scalar(
+    f: _Fun1,
+    args: tuple[object, ...] = (),
+    method: Literal["bisect", "brentq", "brenth", "ridder", "toms748"] | None = None,
+    *,
+    bracket: tuple[onp.ToFloat, onp.ToFloat],
+    fprime: _Falsy | None = None,
+    fprime2: _Falsy | None = None,
+    x0: None = None,
+    x1: None = None,
+    xtol: onp.ToFloat | None = None,
+    rtol: onp.ToFloat | None = None,
+    maxiter: onp.ToJustInt | None = None,
+    options: Mapping[str, object] | None = None,
+) -> RootResults[float]: ...
+@overload  # secant
+def root_scalar(
+    f: _Fun1,
+    args: tuple[object, ...] = (),
+    method: Literal["secant"] | None = None,
+    bracket: None = None,
+    fprime: _Falsy | None = None,
+    fprime2: _Falsy | None = None,
+    *,
+    x0: onp.ToFloat,
+    x1: onp.ToFloat | None = None,
+    xtol: onp.ToFloat | None = None,
+    rtol: onp.ToFloat | None = None,
+    maxiter: onp.ToJustInt | None = None,
+    options: Mapping[str, object] | None = None,
+) -> RootResults[float]: ...
+@overload  # newton
+def root_scalar(
+    f: _Fun1,
+    args: tuple[object, ...] = (),
+    method: Literal["newton"] | None = None,
+    bracket: None = None,
+    fprime: _Fun1 | _Falsy | None = None,
+    fprime2: _Falsy | None = None,
+    *,
+    x0: onp.ToFloat,
+    x1: None = None,
+    xtol: onp.ToFloat | None = None,
+    rtol: onp.ToFloat | None = None,
+    maxiter: onp.ToJustInt | None = None,
+    options: Mapping[str, object] | None = None,
+) -> RootResults[float]: ...
+@overload  # newton  (fprime=True)
+def root_scalar(
+    f: _Fun2,
+    args: tuple[object, ...] = (),
+    method: Literal["newton"] | None = None,
+    bracket: None = None,
+    *,
+    fprime: _Truthy,
+    fprime2: _Falsy | None = None,
+    x0: onp.ToFloat,
+    x1: None = None,
+    xtol: onp.ToFloat | None = None,
+    rtol: onp.ToFloat | None = None,
+    maxiter: onp.ToJustInt | None = None,
+    options: Mapping[str, object] | None = None,
+) -> RootResults[float]: ...
+@overload  # halley
+def root_scalar(
+    f: _Fun1,
+    args: tuple[object, ...] = (),
+    method: Literal["halley"] | None = None,
+    bracket: None = None,
+    *,
+    fprime: _Fun1,
+    fprime2: _Fun1,
+    x0: onp.ToFloat,
+    x1: None = None,
+    xtol: onp.ToFloat | None = None,
+    rtol: onp.ToFloat | None = None,
+    maxiter: onp.ToJustInt | None = None,
+    options: Mapping[str, object] | None = None,
+) -> RootResults[float]: ...
+@overload  # halley (fprime=True)
+def root_scalar(
+    f: _Fun2,
+    args: tuple[object, ...] = (),
+    method: Literal["halley"] | None = None,
+    bracket: None = None,
+    *,
+    fprime: _Truthy,
+    fprime2: _Fun1,
+    x0: onp.ToFloat,
+    x1: None = None,
+    xtol: onp.ToFloat | None = None,
+    rtol: onp.ToFloat | None = None,
+    maxiter: onp.ToJustInt | None = None,
+    options: Mapping[str, object] | None = None,
+) -> RootResults[float]: ...
+@overload  # halley (fprime=True, fprime2=True)
+def root_scalar(
+    f: _Fun3,
+    args: tuple[object, ...] = (),
+    method: Literal["halley"] | None = None,
+    bracket: None = None,
+    *,
+    fprime: _Truthy,
+    fprime2: _Truthy,
+    x0: onp.ToFloat,
+    x1: None = None,
+    xtol: onp.ToFloat | None = None,
+    rtol: onp.ToFloat | None = None,
+    maxiter: onp.ToJustInt | None = None,
+    options: Mapping[str, object] | None = None,
+) -> RootResults[float]: ...
+
+#
+def _root_scalar_brentq_doc() -> None: ...  # undocumented
+def _root_scalar_brenth_doc() -> None: ...  # undocumented
+def _root_scalar_toms748_doc() -> None: ...  # undocumented
+def _root_scalar_secant_doc() -> None: ...  # undocumented
+def _root_scalar_newton_doc() -> None: ...  # undocumented
+def _root_scalar_halley_doc() -> None: ...  # undocumented
+def _root_scalar_ridder_doc() -> None: ...  # undocumented
+def _root_scalar_bisect_doc() -> None: ...  # undocumented

--- a/scipy-stubs/optimize/_typing.pyi
+++ b/scipy-stubs/optimize/_typing.pyi
@@ -16,6 +16,7 @@ __all__ = [
     "MethodLinprog",
     "MethodMimimize",
     "MethodMinimizeScalar",
+    "MethodRootScalar",
     "Solver",
     "TRSolver",
 ]
@@ -73,13 +74,13 @@ _MethodRoot: TypeAlias = Literal[
     "krylov",
     "df-sane",
 ]
-_MethodRootScalar: TypeAlias = Literal["bisect", "brentq", "brenth", "ridder", "toms748", "newton", "secant", "halley"]
+MethodRootScalar: TypeAlias = Literal["bisect", "brentq", "brenth", "ridder", "toms748", "newton", "secant", "halley"]
 _MethodQuadraticAssignment: TypeAlias = Literal["faq", "2opt"]
 MethodAll: TypeAlias = Literal[
     MethodMimimize,
     _MethodRoot,
     MethodMinimizeScalar,
-    _MethodRootScalar,
+    MethodRootScalar,
     MethodLinprog,
     _MethodQuadraticAssignment,
 ]

--- a/scipy-stubs/optimize/_zeros_py.pyi
+++ b/scipy-stubs/optimize/_zeros_py.pyi
@@ -1,167 +1,314 @@
 from collections.abc import Callable
-from typing import Any, Concatenate, Final, Generic, Literal, TypeAlias, TypeVar
+from typing import Any, Concatenate, Final, Generic, Literal, TypeAlias, TypeVar, overload
 
 import numpy as np
 import optype as op
 import optype.numpy as onp
-from scipy._typing import Untyped, UntypedCallable
 from ._optimize import OptimizeResult
+from ._typing import MethodRootScalar
 
 __all__ = ["RootResults", "bisect", "brenth", "brentq", "newton", "ridder", "toms748"]
 
 _Flag: TypeAlias = Literal["converged", "sign error", "convergence error", "value error", "No error"]
+_FlagKey: TypeAlias = Literal[0, -1, -2, -3, -4, 1]
 
 _Float: TypeAlias = float | np.float64
 _Floating: TypeAlias = float | np.floating[Any]
 
-_AnyRoot: TypeAlias = complex | np.inexact[Any] | onp.ArrayND[np.inexact[Any]]
-_RootT_co = TypeVar("_RootT_co", covariant=True, bound=_AnyRoot, default=_Float)
+_T = TypeVar("_T")
+_KT = TypeVar("_KT", bound=_FlagKey)
+_RT = TypeVar("_RT", bound=_Floating)
+_RT_co = TypeVar("_RT_co", bound=_Floating, default=_Float, covariant=True)
+_ToFloatT = TypeVar("_ToFloatT", bound=onp.ToFloat | onp.ToFloatND, default=onp.ToFloat)
 
-_Fn_f_0d: TypeAlias = Callable[Concatenate[float, ...], _Float] | Callable[Concatenate[np.float64, ...], _Floating]
+_Falsy: TypeAlias = Literal[False, 0]
+_Truthy: TypeAlias = Literal[True, 1]
+
+_Fun0D: TypeAlias = Callable[Concatenate[float, ...], onp.ToFloat] | Callable[Concatenate[np.float64, ...], onp.ToFloat]
+_Fun1D: TypeAlias = Callable[Concatenate[onp.Array1D[np.float64], ...], _ToFloatT]
+
+_State: TypeAlias = tuple[_FlagKey, _Float]
+_Bracket: TypeAlias = tuple[_Float, _Float]
 
 ###
 
-CONVERGED: Final = "converged"
-SIGNERR: Final = "sign error"
-CONVERR: Final = "convergence error"
-VALUEERR: Final = "value error"
-INPROGRESS: Final = "No error"
+CONVERGED: Final = "converged"  # 0  # undocumented
+SIGNERR: Final = "sign error"  # -1  # undocumented
+CONVERR: Final = "convergence error"  # -2  # undocumented
+VALUEERR: Final = "value error"  # -3  # undocumented
+INPROGRESS: Final = "No error"  # 1  # undocumented
 
-flag_map: Final[dict[int, str]] = ...
+flag_map: Final[dict[_FlagKey, _Flag]] = ...  # undocumented
 
-class RootResults(OptimizeResult, Generic[_RootT_co]):
-    root: _RootT_co  # readonly
+class RootResults(OptimizeResult, Generic[_RT_co]):
+    root: _RT_co  # readonly
     iterations: Final[int]
     function_calls: Final[int]
     converged: Final[bool]
     flag: Final[_Flag]
-    method: Final[str]
+    method: Final[MethodRootScalar]
 
     def __init__(
         self,
         /,
-        root: _RootT_co,
+        root: _RT_co,
         iterations: int,
         function_calls: int,
-        flag: Literal[0, -1, -2, -3, -4, 1],
-        method: str,
+        flag: _FlagKey,
+        method: MethodRootScalar,
     ) -> None: ...
 
 # undocumented
 class TOMS748Solver:
-    f: UntypedCallable
-    args: tuple[object, ...]
+    f: _Fun0D | None
+    args: tuple[object, ...] | None
     function_calls: int
     iterations: int
     k: int
-    ab: Untyped
-    fab: Untyped
-    d: Untyped
-    fd: Untyped
-    e: Untyped
-    fe: Untyped
-    disp: op.CanBool
-    xtol: onp.ToFloat
-    rtol: _Floating
-    maxiter: op.CanIndex
+    ab: list[_Float]  # size  2
+    fab: list[_Float]  # size 2
+    d: _Float | None
+    fd: _Float | None
+    e: _Float | None
+    fe: _Float | None
+    disp: bool
+    xtol: _Float
+    rtol: _Float
+    maxiter: int
 
-    def __init__(self) -> None: ...
-    def configure(self, xtol: onp.ToFloat, rtol: _Floating, maxiter: op.CanIndex, disp: Untyped, k: Untyped) -> None: ...
-    def get_result(self, x: Untyped, flag: Untyped = ...) -> Untyped: ...
-    def start(self, f: UntypedCallable, a: Untyped, b: Untyped, args: tuple[object, ...] = ()) -> Untyped: ...
-    def get_status(self) -> Untyped: ...
-    def iterate(self) -> Untyped: ...
+    def __init__(self, /) -> None: ...
+    def configure(self, /, xtol: _Float, rtol: _Float, maxiter: int, disp: bool, k: int) -> None: ...
+    def _callf(self, /, x: _Float, error: bool = True) -> onp.ToFloat: ...
+    @overload
+    def get_result(self, /, x: _T, flag: Literal[0] = 0) -> tuple[_T, int, int, Literal[0]]: ...
+    @overload
+    def get_result(self, /, x: _T, flag: _KT) -> tuple[_T, int, int, _KT]: ...
+    def _update_bracket(self, /, c: _Float, fc: _Float) -> _Bracket: ...
+    def start(self, /, f: _Fun0D, a: _Float, b: _Float, args: tuple[object, ...] = ()) -> _State: ...
+    def get_status(self, /) -> _State: ...
+    def iterate(self, /) -> _State: ...
     def solve(
         self,
-        f: UntypedCallable,
-        a: Untyped,
-        b: Untyped,
+        /,
+        f: _Fun0D,
+        a: _Float,
+        b: _Float,
         args: tuple[object, ...] = (),
-        xtol: onp.ToFloat = ...,
-        rtol: _Floating = ...,
+        xtol: _Float = 2e-12,
+        rtol: _Float = ...,
         k: int = 2,
-        maxiter: op.CanIndex = ...,
+        maxiter: int = 100,
         disp: op.CanBool = True,
-    ) -> Untyped: ...
+    ) -> _State: ...
 
 # undocumented
+def _update_bracket(ab: list[_Float] | _Bracket, fab: list[_Float] | _Bracket, c: _Float, fc: _Float) -> _Bracket: ...
+
+# undocumented
+@overload
+def results_c(full_output: _Falsy, r: _T, method: MethodRootScalar) -> _T: ...
+@overload
 def results_c(
-    full_output: op.CanBool,
-    r: tuple[_AnyRoot, int, int, int],
-    method: str,
-) -> tuple[_AnyRoot, int, int, int] | tuple[_AnyRoot, RootResults[_AnyRoot]]: ...
+    full_output: _Truthy,
+    r: tuple[_RT, int, int, _FlagKey],
+    method: MethodRootScalar,
+) -> tuple[_RT, RootResults[_RT]]: ...
 
 # TODO: overload `shape(x0)`: `() | (1) | (1, 1), ... -> root: scalar[_]`, `_ -> root: array[_]`
 # TODO: overload `dtype(x0)`: `floating -> root: _[float64]`; `complexfloating -> root: _[complex128]`
 # TODO: overload `full_output`: `falsy -> root`, `truthy -> (root, r, converged, zero_der)`
+@overload
 def newton(
-    func: UntypedCallable,
-    x0: onp.ToFloat | onp.ToFloatND,
-    fprime: UntypedCallable | None = None,
+    func: _Fun0D,
+    x0: onp.ToFloat,
+    fprime: _Fun0D | None = None,
     args: tuple[object, ...] = (),
-    tol: _Floating = 1.48e-08,
-    maxiter: op.CanIndex = 50,
-    fprime2: UntypedCallable | None = None,
-    x1: onp.ToComplexND | None = None,
-    rtol: _Floating = 0.0,
-    full_output: op.CanBool = False,
-    disp: op.CanBool = True,
-) -> _Float | tuple[_Float, RootResults, onp.ArrayND[np.bool_], onp.ArrayND[np.bool_]]: ...
+    tol: onp.ToFloat = 1.48e-08,
+    maxiter: onp.ToJustInt = 50,
+    fprime2: _Fun0D | None = None,
+    x1: onp.ToFloat | None = None,
+    rtol: onp.ToFloat = 0.0,
+    full_output: _Falsy = False,
+    disp: onp.ToBool = True,
+) -> _Float: ...
+@overload
+def newton(
+    func: _Fun0D,
+    x0: onp.ToFloat,
+    fprime: _Fun0D | None = None,
+    args: tuple[object, ...] = (),
+    tol: onp.ToFloat = 1.48e-08,
+    maxiter: onp.ToJustInt = 50,
+    fprime2: _Fun0D | None = None,
+    x1: onp.ToFloat | None = None,
+    rtol: onp.ToFloat = 0.0,
+    *,
+    full_output: _Truthy,
+    disp: onp.ToBool = True,
+) -> tuple[_Float, RootResults[_Float]]: ...
+@overload
+def newton(
+    func: _Fun1D,
+    x0: onp.ToFloat1D,
+    fprime: _Fun1D[onp.ToFloat1D] | None = None,
+    args: tuple[object, ...] = (),
+    tol: onp.ToFloat = 1.48e-08,
+    maxiter: onp.ToJustInt = 50,
+    fprime2: _Fun1D[onp.ToFloat2D] | None = None,
+    x1: onp.ToFloat1D | None = None,
+    rtol: onp.ToFloat = 0.0,
+    full_output: _Falsy = False,
+    disp: onp.ToBool = True,
+) -> onp.Array1D[np.float64]: ...
+@overload
+def newton(
+    func: _Fun1D,
+    x0: onp.ToFloat1D,
+    fprime: _Fun1D[onp.ToFloat1D] | None = None,
+    args: tuple[object, ...] = (),
+    tol: onp.ToFloat = 1.48e-08,
+    maxiter: onp.ToJustInt = 50,
+    fprime2: _Fun1D[onp.ToFloat2D] | None = None,
+    x1: onp.ToFloat1D | None = None,
+    rtol: onp.ToFloat = 0.0,
+    *,
+    full_output: _Truthy,
+    disp: onp.ToBool = True,
+) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.bool_], onp.Array1D[np.bool_]]: ...
 
-# TODO: overload `full_output`: falsy | truthy => root | (root, r)
+#
+@overload
 def bisect(
-    f: _Fn_f_0d,
+    f: _Fun0D,
     a: onp.ToFloat,
     b: onp.ToFloat,
     args: tuple[object, ...] = (),
     xtol: onp.ToFloat = 2e-12,
-    rtol: _Floating = ...,
-    maxiter: op.CanIndex = 100,
-    full_output: op.CanBool = False,
+    rtol: onp.ToFloat = ...,
+    maxiter: onp.ToJustInt = 100,
+    full_output: _Falsy = False,
     disp: op.CanBool = True,
-) -> _Float | tuple[_Float, RootResults]: ...
+) -> float: ...
+@overload
+def bisect(
+    f: _Fun0D,
+    a: onp.ToFloat,
+    b: onp.ToFloat,
+    args: tuple[object, ...] = (),
+    xtol: onp.ToFloat = 2e-12,
+    rtol: onp.ToFloat = ...,
+    maxiter: onp.ToJustInt = 100,
+    *,
+    full_output: _Truthy,
+    disp: op.CanBool = True,
+) -> tuple[float, RootResults[_Float]]: ...
+
+#
+@overload
 def ridder(
-    f: _Fn_f_0d,
+    f: _Fun0D,
     a: onp.ToFloat,
     b: onp.ToFloat,
     args: tuple[object, ...] = (),
     xtol: onp.ToFloat = 2e-12,
-    rtol: _Floating = ...,
-    maxiter: op.CanIndex = 100,
-    full_output: op.CanBool = False,
+    rtol: onp.ToFloat = ...,
+    maxiter: onp.ToJustInt = 100,
+    full_output: _Falsy = False,
     disp: op.CanBool = True,
-) -> _Float | tuple[_Float, RootResults]: ...
+) -> float: ...
+@overload
+def ridder(
+    f: _Fun0D,
+    a: onp.ToFloat,
+    b: onp.ToFloat,
+    args: tuple[object, ...] = (),
+    xtol: onp.ToFloat = 2e-12,
+    rtol: onp.ToFloat = ...,
+    maxiter: onp.ToJustInt = 100,
+    *,
+    full_output: _Truthy,
+    disp: op.CanBool = True,
+) -> tuple[float, RootResults[_Float]]: ...
+
+#
+@overload
 def brentq(
-    f: _Fn_f_0d,
+    f: _Fun0D,
     a: onp.ToFloat,
     b: onp.ToFloat,
     args: tuple[object, ...] = (),
     xtol: onp.ToFloat = 2e-12,
-    rtol: _Floating = ...,
-    maxiter: op.CanIndex = 100,
-    full_output: op.CanBool = False,
+    rtol: onp.ToFloat = ...,
+    maxiter: onp.ToJustInt = 100,
+    full_output: _Falsy = False,
     disp: op.CanBool = True,
-) -> _Float | tuple[_Float, RootResults]: ...
+) -> float: ...
+@overload
+def brentq(
+    f: _Fun0D,
+    a: onp.ToFloat,
+    b: onp.ToFloat,
+    args: tuple[object, ...] = (),
+    xtol: onp.ToFloat = 2e-12,
+    rtol: onp.ToFloat = ...,
+    maxiter: onp.ToJustInt = 100,
+    *,
+    full_output: _Truthy,
+    disp: op.CanBool = True,
+) -> tuple[float, RootResults[_Float]]: ...
+
+#
+@overload
 def brenth(
-    f: _Fn_f_0d,
+    f: _Fun0D,
     a: onp.ToFloat,
     b: onp.ToFloat,
     args: tuple[object, ...] = (),
     xtol: onp.ToFloat = 2e-12,
-    rtol: _Floating = ...,
-    maxiter: op.CanIndex = 100,
-    full_output: op.CanBool = False,
+    rtol: onp.ToFloat = ...,
+    maxiter: onp.ToJustInt = 100,
+    full_output: _Falsy = False,
     disp: op.CanBool = True,
-) -> _Float | tuple[_Float, RootResults]: ...
+) -> float: ...
+@overload
+def brenth(
+    f: _Fun0D,
+    a: onp.ToFloat,
+    b: onp.ToFloat,
+    args: tuple[object, ...] = (),
+    xtol: onp.ToFloat = 2e-12,
+    rtol: onp.ToFloat = ...,
+    maxiter: onp.ToJustInt = 100,
+    *,
+    full_output: _Truthy,
+    disp: op.CanBool = True,
+) -> tuple[float, RootResults[_Float]]: ...
+
+#
+@overload
 def toms748(
-    f: _Fn_f_0d,
+    f: _Fun0D,
     a: onp.ToFloat,
     b: onp.ToFloat,
     args: tuple[object, ...] = (),
-    k: int = 1,
+    k: onp.ToJustInt = 1,
     xtol: onp.ToFloat = 2e-12,
-    rtol: _Floating = ...,
-    maxiter: op.CanIndex = 100,
-    full_output: op.CanBool = False,
+    rtol: onp.ToFloat = ...,
+    maxiter: onp.ToJustInt = 100,
+    full_output: _Falsy = False,
     disp: op.CanBool = True,
-) -> _Float | tuple[_Float, RootResults]: ...
+) -> np.float64: ...
+@overload
+def toms748(
+    f: _Fun0D,
+    a: onp.ToFloat,
+    b: onp.ToFloat,
+    args: tuple[object, ...] = (),
+    k: onp.ToJustInt = 1,
+    xtol: onp.ToFloat = 2e-12,
+    rtol: onp.ToFloat = ...,
+    maxiter: onp.ToJustInt = 100,
+    *,
+    full_output: _Truthy,
+    disp: op.CanBool = True,
+) -> tuple[np.float64, RootResults[_Float]]: ...

--- a/scipy-stubs/optimize/zeros.pyi
+++ b/scipy-stubs/optimize/zeros.pyi
@@ -1,85 +1,87 @@
 # This file is not meant for public use and will be removed in SciPy v2.0.0.
 
+from collections.abc import Callable
 from typing_extensions import deprecated
+
+from ._zeros_py import RootResults as _RootResults
 
 __all__ = ["RootResults", "bisect", "brenth", "brentq", "newton", "ridder", "toms748"]
 
 @deprecated("will be removed in SciPy v2.0.0")
-class RootResults:
-    def __init__(self, root: object, iterations: object, function_calls: object, flag: object, method: object) -> None: ...
+class RootResults(_RootResults): ...
 
 @deprecated("will be removed in SciPy v2.0.0")
 def newton(
-    func: object,
+    func: Callable[..., object],
     x0: object,
-    fprime: object = ...,
-    args: object = ...,
-    tol: object = ...,
-    maxiter: object = ...,
-    fprime2: object = ...,
+    fprime: Callable[..., object] | None = None,
+    args: tuple[object, ...] = (),
+    tol: float = ...,
+    maxiter: int = ...,
+    fprime2: Callable[..., object] | None = None,
     x1: object = ...,
-    rtol: object = ...,
-    full_output: object = ...,
-    disp: object = ...,
+    rtol: float = ...,
+    full_output: bool = False,
+    disp: bool = True,
 ) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def bisect(
-    f: object,
-    a: object,
-    b: object,
-    args: object = ...,
-    xtol: object = ...,
-    rtol: object = ...,
-    maxiter: object = ...,
-    full_output: object = ...,
-    disp: object = ...,
+    f: Callable[..., object],
+    a: float,
+    b: float,
+    args: tuple[object, ...] = (),
+    xtol: float = ...,
+    rtol: float = ...,
+    maxiter: int = ...,
+    full_output: bool = False,
+    disp: bool = True,
 ) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def ridder(
-    f: object,
-    a: object,
-    b: object,
-    args: object = ...,
-    xtol: object = ...,
-    rtol: object = ...,
-    maxiter: object = ...,
-    full_output: object = ...,
-    disp: object = ...,
+    f: Callable[..., object],
+    a: float,
+    b: float,
+    args: tuple[object, ...] = (),
+    xtol: float = ...,
+    rtol: float = ...,
+    maxiter: int = ...,
+    full_output: bool = False,
+    disp: bool = True,
 ) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def brentq(
-    f: object,
-    a: object,
-    b: object,
-    args: object = ...,
-    xtol: object = ...,
-    rtol: object = ...,
-    maxiter: object = ...,
-    full_output: object = ...,
-    disp: object = ...,
+    f: Callable[..., object],
+    a: float,
+    b: float,
+    args: tuple[object, ...] = (),
+    xtol: float = ...,
+    rtol: float = ...,
+    maxiter: int = ...,
+    full_output: bool = False,
+    disp: bool = True,
 ) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def brenth(
-    f: object,
-    a: object,
-    b: object,
-    args: object = ...,
-    xtol: object = ...,
-    rtol: object = ...,
-    maxiter: object = ...,
-    full_output: object = ...,
-    disp: object = ...,
+    f: Callable[..., object],
+    a: float,
+    b: float,
+    args: tuple[object, ...] = (),
+    xtol: float = ...,
+    rtol: float = ...,
+    maxiter: int = ...,
+    full_output: bool = False,
+    disp: bool = True,
 ) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def toms748(
-    f: object,
-    a: object,
-    b: object,
-    args: object = ...,
+    f: Callable[..., object],
+    a: float,
+    b: float,
+    args: tuple[object, ...] = (),
     k: object = ...,
-    xtol: object = ...,
-    rtol: object = ...,
-    maxiter: object = ...,
-    full_output: object = ...,
-    disp: object = ...,
+    xtol: float = ...,
+    rtol: float = ...,
+    maxiter: int = ...,
+    full_output: bool = False,
+    disp: bool = True,
 ) -> object: ...


### PR DESCRIPTION
This completes the annotations (i.e. filled in every `Untyped*`) of the following public `scipy.optimize` members:

- `root`
- `root_scalar`
- `brentq`
- `brenth`
- `ridder`
- `bisect`
- `newton`
- `toms748`
- `RootResult`

[docs](https://docs.scipy.org/doc/scipy-1.14.1/reference/optimize.html#root-finding)

towards #102 (-60)