### PR TITLE
`optimize`: complete `curve_fit`, `leastsq`, and `fsolve`

### DIFF
--- a/scipy-stubs/optimize/_minpack_py.pyi
+++ b/scipy-stubs/optimize/_minpack_py.pyi
@@ -7,6 +7,7 @@ from scipy._typing import NanPolicy, Untyped, UntypedCallable
 
 __all__ = ["curve_fit", "fixed_point", "fsolve", "leastsq"]
 
+#
 def fsolve(
     func: UntypedCallable,
     x0: Untyped,
@@ -21,6 +22,8 @@ def fsolve(
     factor: int = 100,
     diag: Untyped | None = None,
 ) -> Untyped: ...
+
+#
 def leastsq(
     func: UntypedCallable,
     x0: Untyped,
@@ -36,6 +39,8 @@ def leastsq(
     factor: int = 100,
     diag: Untyped | None = None,
 ) -> Untyped: ...
+
+#
 def curve_fit(
     f: UntypedCallable,
     xdata: Untyped,
@@ -51,13 +56,6 @@ def curve_fit(
     full_output: bool = False,
     nan_policy: NanPolicy | None = None,
     **kwargs: tuple[object, ...],
-) -> Untyped: ...
-def check_gradient(
-    fcn: UntypedCallable,
-    Dfcn: UntypedCallable,
-    x0: Untyped,
-    args: tuple[object, ...] = (),
-    col_deriv: int = 0,
 ) -> Untyped: ...
 
 #

--- a/scipy-stubs/optimize/_minpack_py.pyi
+++ b/scipy-stubs/optimize/_minpack_py.pyi
@@ -1,62 +1,286 @@
-from collections.abc import Callable
-from typing import Concatenate, Literal, overload
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, Concatenate, Literal, TypeAlias, TypedDict, final, overload, type_check_only
+from typing_extensions import Unpack
 
 import numpy as np
+import optype as op
 import optype.numpy as onp
-from scipy._typing import NanPolicy, Untyped, UntypedCallable
+from scipy.sparse import sparray, spmatrix
+from ._constraints import Bounds
 
 __all__ = ["curve_fit", "fixed_point", "fsolve", "leastsq"]
 
+_Fun1D: TypeAlias = Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat1D]
+_Fun2D: TypeAlias = Callable[Concatenate[onp.Array2D[np.float64], ...], onp.ToFloat1D]
+_Jac1D: TypeAlias = Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat2D]
+_Jac2D: TypeAlias = Callable[Concatenate[onp.Array2D[np.float64], ...], onp.ToFloat2D]
+
+# TODO(jorenham): add these "strict" shape-typed array-likes to `optype` (or make the current ones generic)
+_ToFloatScalar: TypeAlias = np.floating[Any] | np.integer[Any] | np.bool_
+_ToStrictFloat1D: TypeAlias = onp.CanArray1D[_ToFloatScalar] | Sequence[onp.ToFloat]
+_ToStrictFloat2D: TypeAlias = onp.CanArray2D[_ToFloatScalar] | Sequence[_ToStrictFloat1D]
+
+_Falsy: TypeAlias = Literal[False, 0]
+_Truthy: TypeAlias = Literal[True, 1]
+
+_JacMethod: TypeAlias = Literal["2-point", "3-point", "cs"]
+_CurveFitMethod: TypeAlias = Literal["lm", "trf", "dogbox"]
+_NanPolicy: TypeAlias = Literal["raise", "omit"]  # no "propagate"
+_IERFlag: TypeAlias = Literal[1, 2, 3, 4, 5, 6, 7, 8]
+
+@final
+@type_check_only
+class _KwargsCurveFit(TypedDict, total=False):
+    ftol: onp.ToFloat
+    xtol: onp.ToFloat
+    gtol: onp.ToFloat
+
+    # leastsq
+    col_deriv: onp.ToBool
+    maxfev: onp.ToJustInt
+    epsfcn: onp.ToFloat | None
+    factor: onp.ToJustInt
+    diag: onp.ToFloat1D | None
+
+    # least_squares
+    x_scale: onp.ToFloat | onp.ToFloatND | Literal["jac"]
+    f_scale: onp.ToFloat
+    loss: (
+        Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat1D]
+        | Literal["linear", "soft_l1", "huber", "cauchy", "arctan"]
+    )
+    diff_step: onp.ToFloat1D | None
+    tr_solver: Literal["exact", "lsmr"]
+    tr_options: Mapping[str, object]
+    jac_sparsity: onp.ToFloat2D | spmatrix | sparray
+    max_nfev: onp.ToJustInt
+    verbose: Literal[0, 1, 2]
+    kwargs: Mapping[str, object]
+
+@type_check_only
+class _InfoDictBase(TypedDict):
+    nfev: int
+    fvec: onp.Array1D[np.float64]
+
+@type_check_only
+class _InfoDictSolve(_InfoDictBase, TypedDict):
+    njev: int
+    fjac: onp.Array2D[np.float64]
+    r: onp.Array1D[np.float64]
+    qtf: onp.Array1D[np.float64]
+
+@type_check_only
+class _InfoDictLSQ(_InfoDictBase, TypedDict):
+    fjac: onp.Array2D[np.float64]
+    ipvt: onp.Array1D[np.int32]
+    qtf: onp.Array1D[np.float64]
+
+_InfoDictCurveFit: TypeAlias = _InfoDictBase | _InfoDictLSQ
+
+###
+
 #
+@overload  # full_output=False (default)
 def fsolve(
-    func: UntypedCallable,
-    x0: Untyped,
+    func: _Fun1D,
+    x0: onp.ToFloat | onp.ToFloat1D,
     args: tuple[object, ...] = (),
-    fprime: UntypedCallable | None = None,
-    full_output: int = 0,
-    col_deriv: int = 0,
-    xtol: float = ...,
-    maxfev: int = 0,
-    band: Untyped | None = None,
-    epsfcn: Untyped | None = None,
-    factor: int = 100,
-    diag: Untyped | None = None,
-) -> Untyped: ...
-
-#
-def leastsq(
-    func: UntypedCallable,
-    x0: Untyped,
+    fprime: _Jac1D | None = None,
+    full_output: _Falsy = 0,
+    col_deriv: onp.ToBool = 0,
+    xtol: onp.ToFloat = 1.49012e-8,
+    maxfev: onp.ToJustInt = 0,
+    band: tuple[onp.ToJustInt, onp.ToJustInt] | None = None,
+    epsfcn: onp.ToFloat | None = None,
+    factor: onp.ToJustInt = 100,
+    diag: onp.ToFloat1D | None = None,
+) -> onp.Array1D[np.float64]: ...
+@overload  # full_output=True (positional)
+def fsolve(
+    func: _Fun1D,
+    x0: onp.ToFloat | onp.ToFloat1D,
+    args: tuple[object, ...],
+    fprime: _Jac1D | None,
+    full_output: _Truthy,
+    col_deriv: onp.ToBool = 0,
+    xtol: onp.ToFloat = 1.49012e-8,
+    maxfev: onp.ToJustInt = 0,
+    band: tuple[onp.ToJustInt, onp.ToJustInt] | None = None,
+    epsfcn: onp.ToFloat | None = None,
+    factor: onp.ToJustInt = 100,
+    diag: onp.ToFloat1D | None = None,
+) -> tuple[onp.Array1D[np.float64], _InfoDictSolve, _IERFlag, str]: ...
+@overload  # full_output=True (keyword)
+def fsolve(
+    func: _Fun1D,
+    x0: onp.ToFloat | onp.ToFloat1D,
     args: tuple[object, ...] = (),
-    Dfun: UntypedCallable | None = None,
-    full_output: bool = False,
-    col_deriv: bool = False,
-    ftol: float = ...,
-    xtol: float = ...,
-    gtol: float = 0.0,
-    maxfev: int = 0,
-    epsfcn: Untyped | None = None,
-    factor: int = 100,
-    diag: Untyped | None = None,
-) -> Untyped: ...
-
-#
-def curve_fit(
-    f: UntypedCallable,
-    xdata: Untyped,
-    ydata: Untyped,
-    p0: Untyped | None = None,
-    sigma: Untyped | None = None,
-    absolute_sigma: bool = False,
-    check_finite: Untyped | None = None,
-    bounds: Untyped = ...,
-    method: Untyped | None = None,
-    jac: Untyped | None = None,
+    fprime: _Jac1D | None = None,
     *,
-    full_output: bool = False,
-    nan_policy: NanPolicy | None = None,
-    **kwargs: tuple[object, ...],
-) -> Untyped: ...
+    full_output: _Truthy,
+    col_deriv: onp.ToBool = 0,
+    xtol: onp.ToFloat = 1.49012e-8,
+    maxfev: onp.ToJustInt = 0,
+    band: tuple[onp.ToJustInt, onp.ToJustInt] | None = None,
+    epsfcn: onp.ToFloat | None = None,
+    factor: onp.ToJustInt = 100,
+    diag: onp.ToFloat1D | None = None,
+) -> tuple[onp.Array1D[np.float64], _InfoDictSolve, _IERFlag, str]: ...
+
+#
+@overload  # full_output=False (default)
+def leastsq(
+    func: _Fun1D,
+    x0: onp.ToFloat1D,
+    args: tuple[object, ...] = (),
+    Dfun: _Jac1D | None = None,
+    full_output: _Falsy = False,
+    col_deriv: onp.ToBool = False,
+    ftol: onp.ToFloat = 1.49012e-8,
+    xtol: onp.ToFloat = 1.49012e-8,
+    gtol: onp.ToFloat = 0.0,
+    maxfev: onp.ToJustInt = 0,
+    epsfcn: onp.ToFloat | None = None,
+    factor: onp.ToJustInt = 100,
+    diag: onp.ToFloat1D | None = None,
+) -> tuple[onp.Array1D[np.float64], _IERFlag]: ...
+@overload  # full_output=True (positional)
+def leastsq(
+    func: _Fun1D,
+    x0: onp.ToFloat1D,
+    args: tuple[object, ...],
+    Dfun: _Jac1D | None,
+    full_output: _Truthy,
+    col_deriv: onp.ToBool = False,
+    ftol: onp.ToFloat = 1.49012e-8,
+    xtol: onp.ToFloat = 1.49012e-8,
+    gtol: onp.ToFloat = 0.0,
+    maxfev: onp.ToJustInt = 0,
+    epsfcn: onp.ToFloat | None = None,
+    factor: onp.ToJustInt = 100,
+    diag: onp.ToFloat1D | None = None,
+) -> tuple[onp.Array1D[np.float64], onp.Array2D[np.float64], _InfoDictLSQ, str, _IERFlag]: ...
+@overload  # full_output=True (keyword)
+def leastsq(
+    func: _Fun1D,
+    x0: onp.ToFloat1D,
+    args: tuple[object, ...] = (),
+    Dfun: _Jac1D | None = None,
+    *,
+    full_output: _Truthy,
+    col_deriv: onp.ToBool = False,
+    ftol: onp.ToFloat = 1.49012e-8,
+    xtol: onp.ToFloat = 1.49012e-8,
+    gtol: onp.ToFloat = 0.0,
+    maxfev: onp.ToJustInt = 0,
+    epsfcn: onp.ToFloat | None = None,
+    factor: onp.ToJustInt = 100,
+    diag: onp.ToFloat1D | None = None,
+) -> tuple[onp.Array1D[np.float64], onp.Array2D[np.float64], _InfoDictLSQ, str, _IERFlag]: ...
+
+#
+@overload  # 1-d `x`, full-output=False
+def curve_fit(
+    f: _Fun1D,
+    xdata: _ToStrictFloat1D,
+    ydata: onp.ToFloat1D,
+    p0: onp.ToFloat1D | None = None,
+    sigma: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D | None = None,
+    absolute_sigma: op.CanBool = False,
+    check_finite: op.CanBool | None = None,
+    bounds: tuple[onp.ToFloat | onp.ToFloat1D, onp.ToFloat | onp.ToFloat1D] | Bounds = ...,
+    method: _CurveFitMethod | None = None,
+    jac: _Jac1D | _JacMethod | None = None,
+    *,
+    full_output: _Falsy = False,
+    nan_policy: _NanPolicy | None = None,
+    **kwargs: Unpack[_KwargsCurveFit],
+) -> tuple[onp.Array1D[np.float64], onp.Array2D[np.float64]]: ...
+@overload  # 1-d `x`, full-output=True
+def curve_fit(
+    f: _Fun1D,
+    xdata: _ToStrictFloat1D,
+    ydata: onp.ToFloat1D,
+    p0: onp.ToFloat1D | None = None,
+    sigma: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D | None = None,
+    absolute_sigma: op.CanBool = False,
+    check_finite: op.CanBool | None = None,
+    bounds: tuple[onp.ToFloat | onp.ToFloat1D, onp.ToFloat | onp.ToFloat1D] | Bounds = ...,
+    method: _CurveFitMethod | None = None,
+    jac: _Jac1D | _JacMethod | None = None,
+    *,
+    full_output: _Truthy,
+    nan_policy: _NanPolicy | None = None,
+    **kwargs: Unpack[_KwargsCurveFit],
+) -> tuple[onp.Array1D[np.float64], onp.Array2D[np.float64], _InfoDictCurveFit, str, _IERFlag]: ...
+@overload  # 2-d `x`, full-output=False
+def curve_fit(
+    f: _Fun2D,
+    xdata: _ToStrictFloat2D,
+    ydata: onp.ToFloat1D,
+    p0: onp.ToFloat1D | None = None,
+    sigma: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D | None = None,
+    absolute_sigma: op.CanBool = False,
+    check_finite: op.CanBool | None = None,
+    bounds: tuple[onp.ToFloat | onp.ToFloat1D, onp.ToFloat | onp.ToFloat1D] | Bounds = ...,
+    method: _CurveFitMethod | None = None,
+    jac: _Jac2D | _JacMethod | None = None,
+    *,
+    full_output: _Falsy = False,
+    nan_policy: _NanPolicy | None = None,
+    **kwargs: Unpack[_KwargsCurveFit],
+) -> tuple[onp.Array2D[np.float64], onp.Array2D[np.float64]]: ...
+@overload  # 2-d `x`, full-output=True
+def curve_fit(
+    f: _Fun2D,
+    xdata: _ToStrictFloat2D,
+    ydata: onp.ToFloat1D,
+    p0: onp.ToFloat1D | None = None,
+    sigma: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D | None = None,
+    absolute_sigma: op.CanBool = False,
+    check_finite: op.CanBool | None = None,
+    bounds: tuple[onp.ToFloat | onp.ToFloat1D, onp.ToFloat | onp.ToFloat1D] | Bounds = ...,
+    method: _CurveFitMethod | None = None,
+    jac: _Jac2D | _JacMethod | None = None,
+    *,
+    full_output: _Truthy,
+    nan_policy: _NanPolicy | None = None,
+    **kwargs: Unpack[_KwargsCurveFit],
+) -> tuple[onp.Array2D[np.float64], onp.Array2D[np.float64], _InfoDictCurveFit, str, _IERFlag]: ...
+@overload  # ?-d `x`, full-output=False
+def curve_fit(
+    f: _Fun1D | _Fun2D,
+    xdata: onp.ToFloat1D | onp.ToFloat2D,
+    ydata: onp.ToFloat1D,
+    p0: onp.ToFloat1D | None = None,
+    sigma: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D | None = None,
+    absolute_sigma: op.CanBool = False,
+    check_finite: op.CanBool | None = None,
+    bounds: tuple[onp.ToFloat | onp.ToFloat1D, onp.ToFloat | onp.ToFloat1D] | Bounds = ...,
+    method: _CurveFitMethod | None = None,
+    jac: _Jac1D | _Jac2D | _JacMethod | None = None,
+    *,
+    full_output: _Falsy = False,
+    nan_policy: _NanPolicy | None = None,
+    **kwargs: Unpack[_KwargsCurveFit],
+) -> tuple[onp.Array1D[np.float64] | onp.Array2D[np.float64], onp.Array2D[np.float64]]: ...
+@overload  # ?-d `x`, full-output=True
+def curve_fit(
+    f: _Fun1D | _Fun2D,
+    xdata: onp.ToFloat1D | onp.ToFloat2D,
+    ydata: onp.ToFloat1D,
+    p0: onp.ToFloat1D | None = None,
+    sigma: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D | None = None,
+    absolute_sigma: op.CanBool = False,
+    check_finite: op.CanBool | None = None,
+    bounds: tuple[onp.ToFloat | onp.ToFloat1D, onp.ToFloat | onp.ToFloat1D] | Bounds = ...,
+    method: _CurveFitMethod | None = None,
+    jac: _Jac1D | _Jac2D | _JacMethod | None = None,
+    *,
+    full_output: _Truthy,
+    nan_policy: _NanPolicy | None = None,
+    **kwargs: Unpack[_KwargsCurveFit],
+) -> tuple[onp.Array1D[np.float64] | onp.Array2D[np.float64], onp.Array2D[np.float64], _InfoDictCurveFit, str, _IERFlag]: ...
 
 #
 @overload  # 0-d real


### PR DESCRIPTION
the common denominator of these functions, is that they all live in the `scipy.optimize._minpack_py` module

docs:

- [`scipy.optimize.curve_fit`](https://docs.scipy.org/doc/scipy-1.14.1/reference/generated/scipy.optimize.curve_fit.html)
- [`scipy.optimize.leastsq`](https://docs.scipy.org/doc/scipy-1.14.1/reference/generated/scipy.optimize.leastsq.html)
- [`scipy.optimize.fsolve`](https://docs.scipy.org/doc/scipy-1.14.1/reference/generated/scipy.optimize.fsolve.html)

towards #102 (-29)