### PR TITLE
test with the oldest supported numpy version in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   OLDEST_SUPPORTED_PYTHON: "3.10"
-  OLDEST_SUPPORTED_NUMPY: "1.24"
+  OLDEST_SUPPORTED_NUMPY: "1.24.3"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,16 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  OLDEST_SUPPORTED_PYTHON: "3.10"
+  OLDEST_SUPPORTED_NUMPY: "1.24"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  lint-and-typecheck:
+  lint:
     timeout-minutes: 5
     runs-on: ubuntu-latest
 
@@ -27,7 +31,6 @@ jobs:
 
       - run: |
           pipx install poetry poethepoet
-          poetry config virtualenvs.create true --local
           poetry config virtualenvs.in-project true --local
 
       - uses: actions/setup-python@v5
@@ -41,22 +44,21 @@ jobs:
       - name: lint
         run: poe lint
 
-      - name: typetest
-        run: poe typetest
-
       - name: basedmypy
         run: poe mypy
 
       - name: basedpyright
         run: poe pyright
 
-  stubtest:
+  typetest:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - run: pipx install poetry poethepoet
+      - run: |
+          pipx install poetry poethepoet
+          poetry config virtualenvs.in-project true --local
 
       - uses: actions/setup-python@v5
         with:
@@ -66,5 +68,34 @@ jobs:
       - name: install
         run: poetry install
 
-      - name: Run stubtest
+      - name: typetest
+        run: poe typetest
+
+      - name: stubtest
+        run: poe stubtest
+
+  typetest-oldest-supported-numpy:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: |
+          pipx install poetry poethepoet
+          poetry config virtualenvs.in-project true --local
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.OLDEST_SUPPORTED_PYTHON }}
+          cache: poetry
+
+      - name: install
+        run: |
+          poetry install
+          poetry run pip install --upgrade numpy==$OLDEST_SUPPORTED_NUMPY
+
+      - name: typetest
+        run: poe typetest
+
+      - name: stubtest
         run: poe stubtest

--- a/scipy-stubs/integrate/_quad_vec.pyi
+++ b/scipy-stubs/integrate/_quad_vec.pyi
@@ -1,29 +1,28 @@
 import collections
 from collections.abc import Callable
-from typing import Any, Final, Generic, Literal, NoReturn, Protocol, TypeAlias, overload, type_check_only
-from typing_extensions import Never, TypeVar, TypeVarTuple, Unpack, override
+from typing import Any, Concatenate, Final, Generic, Literal, NoReturn, Protocol, TypeAlias, overload, type_check_only
+from typing_extensions import Never, TypeVar, override
 
 import numpy as np
-import numpy.typing as npt
 import optype as op
 import optype.numpy as onp
 
-_Ts = TypeVarTuple("_Ts", default=Unpack[tuple[()]])
 _S = TypeVar("_S")
 _T = TypeVar("_T")
 _VT = TypeVar("_VT", default=object)
+_NDT_co = TypeVar("_NDT_co", bound=_FloatingND, default=_FloatingND, covariant=True)
+_SCT_co = TypeVar("_SCT_co", bound=np.floating[Any], default=np.float64, covariant=True)
 
-_FloatND: TypeAlias = onp.ArrayND[np.floating[Any]] | float | np.floating[Any]
-_NDT_f = TypeVar("_NDT_f", bound=_FloatND)
-_NDT_f_co = TypeVar("_NDT_f_co", bound=_FloatND, covariant=True, default=_FloatND)
-_SCT_f_co = TypeVar("_SCT_f_co", bound=np.floating[Any], covariant=True, default=np.float64)
+_Floating: TypeAlias = float | np.floating[Any]
+_FloatingND: TypeAlias = onp.ArrayND[np.floating[Any]] | _Floating
 
-_ShapeT = TypeVar("_ShapeT", bound=tuple[int, ...])
-_NBT = TypeVar("_NBT", bound=npt.NBitBase)
+_Fun: TypeAlias = Callable[Concatenate[float, ...], _T] | Callable[Concatenate[np.float64, ...], _T]
 
-@type_check_only
-class _QuadVecFunc(Protocol[_NDT_f_co, Unpack[_Ts]]):
-    def __call__(self, x: float, /, *args: Unpack[_Ts]) -> _NDT_f_co: ...
+_Falsy: TypeAlias = Literal[False, 0] | None
+_Truthy: TypeAlias = Literal[True, 1]
+
+_Norm: TypeAlias = Literal["max", "2"]
+_Quadrature: TypeAlias = Literal["gk21", "gk15", "trapezoid"]
 
 @type_check_only
 class _DoesMap(Protocol):
@@ -35,26 +34,26 @@ class _DoesMap(Protocol):
     ) -> op.CanIter[op.CanIterSelf[_T]]: ...
 
 @type_check_only
-class _InfiniteFunc(Protocol[_NDT_f_co]):
+class _InfiniteFunc(Protocol[_NDT_co]):
     def get_t(self, /, x: float) -> float: ...
-    def __call__(self, /, t: float) -> _NDT_f_co: ...
+    def __call__(self, /, t: float) -> _NDT_co: ...
 
 class LRUDict(collections.OrderedDict[tuple[float, float], _VT], Generic[_VT]):
     def __init__(self, /, max_size: int) -> None: ...
     @override
     def update(self, other: Never, /) -> NoReturn: ...  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride]
 
-class SemiInfiniteFunc(_InfiniteFunc[_NDT_f_co], Generic[_NDT_f_co]):
-    def __init__(self, /, func: Callable[[float], _NDT_f_co], start: float, infty: bool) -> None: ...
+class SemiInfiniteFunc(_InfiniteFunc[_NDT_co], Generic[_NDT_co]):
+    def __init__(self, /, func: Callable[[float], _NDT_co], start: float, infty: bool) -> None: ...
 
-class DoubleInfiniteFunc(_InfiniteFunc, Generic[_NDT_f_co]):
-    def __init__(self, /, func: Callable[[float], _NDT_f_co]) -> None: ...
+class DoubleInfiniteFunc(_InfiniteFunc, Generic[_NDT_co]):
+    def __init__(self, /, func: Callable[[float], _NDT_co]) -> None: ...
 
 # NOTE: This is only used as "info dict" for `quad_vec(..., full_output=True)`,
 # even though, confusingly, it is not even even a mapping.
 # NOTE: Because this "bunch" is only used as "info dict" (and nowhere else),
 # its the ~keys~ attributes have been annotated right here.
-class _Bunch(Generic[_SCT_f_co]):
+class _Bunch(Generic[_SCT_co]):
     def __init__(
         self,
         /,
@@ -65,7 +64,7 @@ class _Bunch(Generic[_SCT_f_co]):
         message: str,
         intervals: onp.Array2D[np.float64],
         errors: onp.Array1D[np.float64],
-        integrals: onp.Array2D[_SCT_f_co],
+        integrals: onp.Array2D[_SCT_co],
     ) -> None: ...
     success: Final[bool]
     status: Final[Literal[0, 1, 2]]
@@ -73,92 +72,73 @@ class _Bunch(Generic[_SCT_f_co]):
     message: Final[str]
     intervals: Final[onp.Array2D[np.float64]]
     errors: Final[onp.Array1D[np.float64]]
-    integrals: onp.Array2D[_SCT_f_co]
+    integrals: onp.Array2D[_SCT_co]
 
 @overload
+def quad_vec(  # scalar function, full_output=False (default)
+    f: _Fun[onp.ToFloat],
+    a: onp.ToFloat,
+    b: onp.ToFloat,
+    epsabs: _Floating = 1e-200,
+    epsrel: _Floating = 1e-08,
+    norm: _Norm = "2",
+    cache_size: onp.ToJustInt | float = 100_000_000,
+    limit: onp.ToFloat = 10_000,
+    workers: onp.ToJustInt | _DoesMap = 1,
+    points: onp.ToFloat1D | None = None,
+    quadrature: _Quadrature | None = None,
+    full_output: _Falsy = False,
+    *,
+    args: tuple[object, ...] = (),
+) -> tuple[_Floating, float]: ...
+@overload  # scalar function, full_output=True
 def quad_vec(
-    f: Callable[[float], _NDT_f],
-    a: float,
-    b: float,
-    epsabs: float = 1e-200,
-    epsrel: float = 1e-08,
-    norm: Literal["max", "2"] = "2",
-    cache_size: float = 100_000_000,
-    limit: float = 10_000,
-    workers: int | _DoesMap = 1,
-    points: op.CanIter[op.CanNext[float]] | None = None,
-    quadrature: Literal["gk21", "gk15", "trapezoid"] | None = None,
-    full_output: Literal[False, 0] | None = False,
+    f: _Fun[onp.ToFloat],
+    a: onp.ToFloat,
+    b: onp.ToFloat,
+    epsabs: _Floating = 1e-200,
+    epsrel: _Floating = 1e-08,
+    norm: _Norm = "2",
+    cache_size: onp.ToJustInt | float = 100_000_000,
+    limit: onp.ToFloat = 10_000,
+    workers: onp.ToJustInt | _DoesMap = 1,
+    points: onp.ToFloat1D | None = None,
+    quadrature: _Quadrature | None = None,
     *,
-    args: tuple[()] = ...,
-) -> tuple[_NDT_f, float]: ...
-@overload
+    full_output: _Truthy,
+    args: tuple[object, ...] = (),
+) -> tuple[np.floating[Any], float, _Bunch[np.floating[Any]]]: ...
+@overload  # vector function, full_output=False (default)
 def quad_vec(
-    f: _QuadVecFunc[_NDT_f, Unpack[_Ts]],
-    a: float,
-    b: float,
-    epsabs: float = 1e-200,
-    epsrel: float = 1e-08,
-    norm: Literal["max", "2"] = "2",
-    cache_size: float = 100_000_000,
-    limit: float = 10_000,
-    workers: int | _DoesMap = 1,
-    points: op.CanIter[op.CanNext[float]] | None = None,
-    quadrature: Literal["gk21", "gk15", "trapezoid"] | None = None,
-    full_output: Literal[False, 0] | None = False,
+    f: _Fun[onp.ToFloat1D],
+    a: onp.ToFloat,
+    b: onp.ToFloat,
+    epsabs: _Floating = 1e-200,
+    epsrel: _Floating = 1e-08,
+    norm: _Norm = "2",
+    cache_size: onp.ToJustInt | float = 100_000_000,
+    limit: onp.ToFloat = 10_000,
+    workers: onp.ToJustInt | _DoesMap = 1,
+    points: onp.ToFloat1D | None = None,
+    quadrature: _Quadrature | None = None,
     *,
-    args: tuple[Unpack[_Ts]],
-) -> tuple[_NDT_f, float]: ...
-
-# false positive (basedmypy==1.6.0 / mypy==1.11.1)
-@overload
-def quad_vec(  # type: ignore[overload-overlap]
-    f: _QuadVecFunc[float | np.float64, Unpack[_Ts]],
-    a: float,
-    b: float,
-    epsabs: float = 1e-200,
-    epsrel: float = 1e-08,
-    norm: Literal["max", "2"] = "2",
-    cache_size: float = 100_000_000,
-    limit: float = 10_000,
-    workers: int | _DoesMap = 1,
-    points: op.CanIter[op.CanNext[float]] | None = None,
-    quadrature: Literal["gk21", "gk15", "trapezoid"] | None = None,
-    *,
-    full_output: Literal[True, 1],
-    args: tuple[Unpack[_Ts]] = ...,
-) -> tuple[float | np.float64, float, _Bunch[np.float64]]: ...
-@overload
+    full_output: _Falsy,
+    args: tuple[object, ...] = (),
+) -> tuple[onp.Array1D[np.floating[Any]], float]: ...
+@overload  # vector function, full_output=True
 def quad_vec(
-    f: _QuadVecFunc[np.floating[_NBT], Unpack[_Ts]],
-    a: float,
-    b: float,
-    epsabs: float = 1e-200,
-    epsrel: float = 1e-08,
-    norm: Literal["max", "2"] = "2",
-    cache_size: float = 100_000_000,
-    limit: float = 10_000,
-    workers: int | _DoesMap = 1,
-    points: op.CanIter[op.CanNext[float]] | None = None,
-    quadrature: Literal["gk21", "gk15", "trapezoid"] | None = None,
+    f: _Fun[onp.ToFloat1D],
+    a: onp.ToFloat,
+    b: onp.ToFloat,
+    epsabs: _Floating = 1e-200,
+    epsrel: _Floating = 1e-08,
+    norm: _Norm = "2",
+    cache_size: onp.ToJustInt | float = 100_000_000,
+    limit: onp.ToFloat = 10_000,
+    workers: onp.ToJustInt | _DoesMap = 1,
+    points: onp.ToFloat1D | None = None,
+    quadrature: _Quadrature | None = None,
     *,
-    full_output: Literal[True, 1],
-    args: tuple[Unpack[_Ts]] = ...,
-) -> tuple[np.floating[_NBT], float, _Bunch[np.floating[_NBT]]]: ...
-@overload
-def quad_vec(
-    f: _QuadVecFunc[onp.Array[_ShapeT, np.floating[_NBT]], Unpack[_Ts]],
-    a: float,
-    b: float,
-    epsabs: float = 1e-200,
-    epsrel: float = 1e-08,
-    norm: Literal["max", "2"] = "2",
-    cache_size: float = 100_000_000,
-    limit: float = 10_000,
-    workers: int | _DoesMap = 1,
-    points: op.CanIter[op.CanNext[float]] | None = None,
-    quadrature: Literal["gk21", "gk15", "trapezoid"] | None = None,
-    *,
-    full_output: Literal[True, 1],
-    args: tuple[Unpack[_Ts]] = ...,
-) -> tuple[onp.Array[_ShapeT, np.floating[_NBT]], float, _Bunch[np.floating[_NBT]]]: ...
+    full_output: _Truthy,
+    args: tuple[object, ...] = (),
+) -> tuple[onp.Array1D[np.floating[Any]], float, _Bunch[np.floating[Any]]]: ...

--- a/scipy-stubs/optimize/_optimize.pyi
+++ b/scipy-stubs/optimize/_optimize.pyi
@@ -72,7 +72,7 @@ _AllVecs: TypeAlias = list[_Int1D | _Float1D]
 
 _XT_contra = TypeVar("_XT_contra", contravariant=True, bound=_Array_1d, default=_Float1D)
 _ValueT_co = TypeVar("_ValueT_co", covariant=True, bound=float | np.floating[Any], default=_Float)
-_JacT_co = TypeVar("_JacT_co", covariant=True, bound=_Array_f, default=_Float1D)
+_JacT_co = TypeVar("_JacT_co", covariant=True, bound=_Float1D | _Float2D, default=_Float1D)
 
 @type_check_only
 class _DoesFMin(Protocol):


### PR DESCRIPTION
resolves #81

this also caught a minor bug in `optimize._optimize` and one in `integrate.quad_vec` with `numpy<2.2`