### PR TITLE
`optimize`: complete `fmin_l_bfgs_b` and `LbfgsInvHessProduct`

### DIFF
--- a/scipy-stubs/optimize/_lbfgsb_py.pyi
+++ b/scipy-stubs/optimize/_lbfgsb_py.pyi
@@ -1,31 +1,49 @@
-from scipy._typing import Untyped
+from collections.abc import Callable, Sequence
+from typing import Concatenate, Final, Literal, TypeAlias, TypedDict, type_check_only
+
+import numpy as np
+import optype.numpy as onp
 from scipy.sparse.linalg import LinearOperator
 
 __all__ = ["LbfgsInvHessProduct", "fmin_l_bfgs_b"]
 
-def fmin_l_bfgs_b(
-    func: Untyped,
-    x0: Untyped,
-    fprime: Untyped | None = None,
-    args: Untyped = (),
-    approx_grad: int = 0,
-    bounds: Untyped | None = None,
-    m: int = 10,
-    factr: float = 10000000.0,
-    pgtol: float = 1e-05,
-    epsilon: float = 1e-08,
-    iprint: int = -1,
-    maxfun: int = 15000,
-    maxiter: int = 15000,
-    disp: Untyped | None = None,
-    callback: Untyped | None = None,
-    maxls: int = 20,
-) -> Untyped: ...
+_Ignored: TypeAlias = object
+
+@type_check_only
+class _InfoDict(TypedDict):
+    grad: onp.Array1D[np.float64]
+    task: str  # undocumented
+    funcalls: int
+    nit: int
+    warnflag: Literal[0, 1, 2]
+
+#
 
 class LbfgsInvHessProduct(LinearOperator):
-    sk: Untyped
-    yk: Untyped
-    n_corrs: Untyped
-    rho: Untyped
-    def __init__(self, /, sk: Untyped, yk: Untyped) -> None: ...
-    def todense(self, /) -> Untyped: ...
+    sk: Final[onp.Array2D[np.float64]]
+    yk: Final[onp.Array2D[np.float64]]
+    n_corrs: Final[int]
+    rho: Final[float | np.float64]
+
+    def __init__(self, /, sk: onp.ToFloat2D, yk: onp.ToFloat2D) -> None: ...
+    def _matvec(self, /, x: onp.ToFloat1D | onp.ToFloat2D) -> onp.Array1D[np.float64]: ...
+    def todense(self, /) -> onp.Array2D[np.float64]: ...
+
+def fmin_l_bfgs_b(
+    func: Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat],
+    x0: onp.ToFloat | onp.ToFloat1D,
+    fprime: Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat1D] | None = None,
+    args: tuple[object, ...] = (),
+    approx_grad: onp.ToBool = 0,
+    bounds: Sequence[tuple[onp.ToFloat, onp.ToFloat]] | None = None,
+    m: onp.ToJustInt = 10,
+    factr: onp.ToFloat = 1e7,
+    pgtol: onp.ToFloat = 1e-5,
+    epsilon: onp.ToFloat = 1e-8,
+    iprint: onp.ToJustInt = -1,
+    maxfun: onp.ToJustInt = 15_000,
+    maxiter: onp.ToJustInt = 15_000,
+    disp: onp.ToJustInt | None = None,
+    callback: Callable[[onp.Array1D[np.float64]], _Ignored] | None = None,
+    maxls: onp.ToJustInt = 20,
+) -> tuple[onp.Array1D[np.float64], float | np.float64, _InfoDict]: ...


### PR DESCRIPTION
this completes the following `scipy.optimize` members:

- [`fmin_l_bfgs_b`](https://docs.scipy.org/doc/scipy-1.14.1/reference/generated/scipy.optimize.fmin_l_bfgs_b.html) (legacy)
- [`LbfgsInvHessProduct`](https://docs.scipy.org/doc/scipy-1.14.1/reference/generated/scipy.optimize.LbfgsInvHessProduct.html)

towards #102