### PR TITLE
`linalg._decomp*`: add overloads for shapes and dtypes

### DIFF
--- a/scipy-stubs/linalg/_decomp_cholesky.pyi
+++ b/scipy-stubs/linalg/_decomp_cholesky.pyi
@@ -1,38 +1,92 @@
-from typing import Any
+from typing import Any, TypeAlias, overload
 
 import numpy as np
-import numpy.typing as npt
 import optype.numpy as onp
 
 __all__ = ["cho_factor", "cho_solve", "cho_solve_banded", "cholesky", "cholesky_banded"]
 
+_Float2D: TypeAlias = onp.Array2D[np.floating[Any]]
+_FloatND: TypeAlias = onp.ArrayND[np.floating[Any]]
+_Complex2D: TypeAlias = onp.Array2D[np.inexact[Any]]
+_ComplexND: TypeAlias = onp.ArrayND[np.inexact[Any]]
+
+###
+
+@overload
 def cholesky(
-    a: npt.ArrayLike,
-    lower: bool = False,
-    overwrite_a: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.inexact[Any]]: ...
+    a: onp.ToFloat2D,
+    lower: onp.ToBool = False,
+    overwrite_a: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Float2D: ...
+@overload
+def cholesky(
+    a: onp.ToComplex2D,
+    lower: onp.ToBool = False,
+    overwrite_a: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Complex2D: ...
+
+#
+@overload
 def cho_factor(
-    a: npt.ArrayLike,
-    lower: bool = False,
-    overwrite_a: bool = False,
-    check_finite: bool = True,
-) -> tuple[onp.ArrayND[np.inexact[Any]], bool]: ...
+    a: onp.ToFloat2D,
+    lower: onp.ToBool = False,
+    overwrite_a: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> tuple[_FloatND, bool]: ...
+@overload
+def cho_factor(
+    a: onp.ToComplex2D,
+    lower: onp.ToBool = False,
+    overwrite_a: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> tuple[_ComplexND, bool]: ...
+
+#
+@overload
 def cho_solve(
-    c_and_lower: tuple[npt.ArrayLike, bool],
-    b: npt.ArrayLike,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.ArrayND[np.inexact[Any]]: ...
+    c_and_lower: tuple[onp.ToFloat2D, onp.ToBool],
+    b: onp.ToFloat1D,
+    overwrite_b: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Float2D: ...
+@overload
+def cho_solve(
+    c_and_lower: tuple[onp.ToComplex2D, onp.ToBool],
+    b: onp.ToComplex1D,
+    overwrite_b: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Complex2D: ...
+
+#
+@overload
 def cholesky_banded(
-    ab: npt.ArrayLike,
-    overwrite_ab: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.inexact[Any]]: ...
+    ab: onp.ToFloat2D,
+    overwrite_ab: onp.ToBool = False,
+    lower: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Float2D: ...
+@overload
+def cholesky_banded(
+    ab: onp.ToComplex2D,
+    overwrite_ab: onp.ToBool = False,
+    lower: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Complex2D: ...
+
+#
+@overload
 def cho_solve_banded(
-    cb_and_lower: tuple[npt.ArrayLike, bool],
-    b: npt.ArrayLike,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.inexact[Any]]: ...
+    cb_and_lower: tuple[onp.ToFloat2D, onp.ToBool],
+    b: onp.ToComplex1D,
+    overwrite_b: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Complex2D: ...
+@overload
+def cho_solve_banded(
+    cb_and_lower: tuple[onp.ToComplex2D, onp.ToBool],
+    b: onp.ToComplex1D,
+    overwrite_b: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Complex2D: ...

--- a/scipy-stubs/linalg/_decomp_cossin.pyi
+++ b/scipy-stubs/linalg/_decomp_cossin.pyi
@@ -1,38 +1,62 @@
-from typing import Any, Literal, TypeAlias, overload
+from collections.abc import Iterable
+from typing import Any, Literal, TypeAlias, TypeVar, overload
 
 import numpy as np
-import numpy.typing as npt
-import optype as op
 import optype.numpy as onp
 import optype.typing as opt
 
 __all__ = ["cossin"]
 
-_Array_f_1d: TypeAlias = onp.Array1D[np.floating[Any]]
-_Array_f_2d: TypeAlias = onp.Array2D[np.floating[Any]]
-_Array_c_2d: TypeAlias = onp.Array2D[np.complexfloating[Any, Any]]
+_T = TypeVar("_T")
+_Tuple2: TypeAlias = tuple[_T, _T]
+_Tuple3: TypeAlias = tuple[_T, _T, _T]
 
-@overload
+_Falsy: TypeAlias = Literal[False, 0]
+_Truthy: TypeAlias = Literal[True, 1]
+
+_Float1D: TypeAlias = onp.Array1D[np.floating[Any]]
+_Float2D: TypeAlias = onp.Array2D[np.floating[Any]]
+_Complex2D: TypeAlias = onp.Array2D[np.inexact[Any]]
+
+@overload  # (float[:, :], separate=False) -> float[:, :]**3
 def cossin(
-    X: npt.ArrayLike | op.CanIter[op.CanNext[npt.ArrayLike]],
+    X: onp.ToFloat2D | Iterable[onp.ToFloat2D],
     p: opt.AnyInt | None = None,
     q: opt.AnyInt | None = None,
-    separate: Literal[False] = False,
-    swap_sign: bool = False,
-    compute_u: bool = True,
-    compute_vh: bool = True,
-) -> tuple[_Array_f_2d, _Array_f_2d, _Array_f_2d] | tuple[_Array_c_2d, _Array_f_2d, _Array_c_2d]: ...
-@overload
+    separate: _Falsy = False,
+    swap_sign: onp.ToBool = False,
+    compute_u: onp.ToBool = True,
+    compute_vh: onp.ToBool = True,
+) -> _Tuple3[_Float2D]: ...
+@overload  # (float[:, :], *, separate=True) -> (float[:, :]**2, float[:], float[:, :]**2)
 def cossin(
-    X: npt.ArrayLike | op.CanIter[op.CanNext[npt.ArrayLike]],
+    X: onp.ToFloat2D | Iterable[onp.ToFloat2D],
     p: opt.AnyInt | None = None,
     q: opt.AnyInt | None = None,
     *,
-    separate: Literal[True],
-    swap_sign: bool = False,
-    compute_u: bool = True,
-    compute_vh: bool = True,
-) -> (
-    tuple[tuple[_Array_f_2d, _Array_f_2d], _Array_f_1d, tuple[_Array_f_2d, _Array_f_2d]]
-    | tuple[tuple[_Array_c_2d, _Array_c_2d], _Array_f_1d, tuple[_Array_c_2d, _Array_c_2d]]
-): ...
+    separate: _Truthy,
+    swap_sign: onp.ToBool = False,
+    compute_u: onp.ToBool = True,
+    compute_vh: onp.ToBool = True,
+) -> tuple[_Tuple2[_Float2D], _Float1D, _Tuple2[_Float2D]]: ...
+@overload  # (complex[:, :], separate=False) -> complex[:, :]**3
+def cossin(
+    X: onp.ToComplex2D | Iterable[onp.ToComplex2D],
+    p: opt.AnyInt | None = None,
+    q: opt.AnyInt | None = None,
+    separate: _Falsy = False,
+    swap_sign: onp.ToBool = False,
+    compute_u: onp.ToBool = True,
+    compute_vh: onp.ToBool = True,
+) -> _Tuple3[_Complex2D]: ...
+@overload  # (complex[:, :], separate=True) -> (complex[:, :]**2, float[:], complex[:, :]**2)
+def cossin(
+    X: onp.ToComplex2D | Iterable[onp.ToComplex2D],
+    p: opt.AnyInt | None = None,
+    q: opt.AnyInt | None = None,
+    *,
+    separate: _Truthy,
+    swap_sign: onp.ToBool = False,
+    compute_u: onp.ToBool = True,
+    compute_vh: onp.ToBool = True,
+) -> tuple[_Tuple2[_Complex2D], _Float1D, _Tuple2[_Complex2D]]: ...

--- a/scipy-stubs/linalg/_decomp_ldl.pyi
+++ b/scipy-stubs/linalg/_decomp_ldl.pyi
@@ -1,15 +1,29 @@
-from typing import Any
+from typing import Any, TypeAlias, overload
 
 import numpy as np
-import numpy.typing as npt
 import optype.numpy as onp
 
 __all__ = ["ldl"]
 
+_IntP1D: TypeAlias = onp.Array1D[np.intp]
+_Float2D: TypeAlias = onp.Array2D[np.floating[Any]]
+_Complex2D: TypeAlias = onp.Array2D[np.inexact[Any]]
+
+###
+
+@overload
 def ldl(
-    A: npt.ArrayLike,
-    lower: bool = True,
-    hermitian: bool = True,
-    overwrite_a: bool = False,
-    check_finite: bool = True,
-) -> tuple[onp.Array2D[np.inexact[Any]], onp.Array2D[np.inexact[Any]], onp.Array1D[np.intp]]: ...
+    A: onp.ToFloat2D,
+    lower: onp.ToBool = True,
+    hermitian: onp.ToBool = True,
+    overwrite_a: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Float2D, _Float2D, _IntP1D]: ...
+@overload
+def ldl(
+    A: onp.ToComplex2D,
+    lower: onp.ToBool = True,
+    hermitian: onp.ToBool = True,
+    overwrite_a: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Complex2D, _Complex2D, _IntP1D]: ...

--- a/scipy-stubs/linalg/_decomp_lu.pyi
+++ b/scipy-stubs/linalg/_decomp_lu.pyi
@@ -1,62 +1,120 @@
 from typing import Any, Literal, TypeAlias, overload
 
 import numpy as np
-import numpy.typing as npt
 import optype.numpy as onp
 
 __all__ = ["lu", "lu_factor", "lu_solve"]
 
-_Array_i: TypeAlias = onp.ArrayND[np.intp]
-_Array_fc: TypeAlias = onp.ArrayND[np.inexact[Any]]
-_Array_fc_1d: TypeAlias = onp.Array1D[np.inexact[Any]]
-_Array_fc_2d: TypeAlias = onp.Array2D[np.inexact[Any]]
+_Falsy: TypeAlias = Literal[False, 0]
+_Truthy: TypeAlias = Literal[True, 1]
 
+_IntPND: TypeAlias = onp.ArrayND[np.intp]
+
+_Float1D: TypeAlias = onp.Array1D[np.floating[Any]]
+_Float2D: TypeAlias = onp.Array2D[np.floating[Any]]
+_FloatND: TypeAlias = onp.ArrayND[np.floating[Any], onp.AtLeast2D]
+
+_Complex1D: TypeAlias = onp.Array1D[np.inexact[Any]]
+_Complex2D: TypeAlias = onp.Array2D[np.inexact[Any]]
+_ComplexND: TypeAlias = onp.ArrayND[np.inexact[Any], onp.AtLeast2D]
+
+_Trans: TypeAlias = Literal[0, 1, 2]
+
+@overload  # float[:, :] -> (float[:, :], float[:])
+def lu_factor(
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Float2D, _Float1D]: ...
+@overload  # complex[:, :] -> (complex[:, :], complex[:])
 def lu_factor(
     a: onp.ToComplex2D,
-    overwrite_a: bool = False,
-    check_finite: bool = True,
-) -> tuple[_Array_fc_2d, _Array_fc_1d]: ...
+    overwrite_a: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Complex2D, _Complex1D]: ...
 
 #
+@overload  # (float[:, :], float[:]) -> float[:, :]
 def lu_solve(
-    lu_and_piv: tuple[_Array_fc_2d, _Array_fc_1d],
-    b: npt.ArrayLike,
-    trans: Literal[0, 1, 2] = 0,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> _Array_fc_2d: ...
+    lu_and_piv: tuple[_Float2D, _Float1D],
+    b: onp.ToFloat1D,
+    trans: _Trans = 0,
+    overwrite_b: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Float2D: ...
+@overload  # (complex[:, :], complex[:]) -> complex[:, :]
+def lu_solve(
+    lu_and_piv: tuple[_Complex2D, _Complex1D],
+    b: onp.ToComplex1D,
+    trans: _Trans = 0,
+    overwrite_b: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Complex2D: ...
 
 #
-@overload
+@overload  # (float[:, :], permute_l=False, p_indices=False) -> (float[...], float[...], float[...])
 def lu(
-    a: onp.ToComplex2D,
-    permute_l: Literal[False, 0] = False,
-    overwrite_a: bool = False,
-    check_finite: bool = True,
-    p_indices: Literal[False] = False,
-) -> tuple[_Array_fc, _Array_fc, _Array_fc]: ...
-@overload
+    a: onp.ToFloat2D,
+    permute_l: _Falsy = False,
+    overwrite_a: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+    p_indices: _Falsy = False,
+) -> tuple[_FloatND, _FloatND, _FloatND]: ...
+@overload  # (float[:, :], permute_l=False, p_indices=True, /) -> (intp[...], float[...], float[...])
 def lu(
-    a: onp.ToComplex2D,
-    permute_l: Literal[False],
-    overwrite_a: bool,
-    check_finite: bool,
-    p_indices: Literal[True],
-) -> tuple[_Array_i, _Array_fc, _Array_fc]: ...
-@overload
+    a: onp.ToFloat2D,
+    permute_l: _Falsy,
+    overwrite_a: onp.ToBool,
+    check_finite: onp.ToBool,
+    p_indices: _Truthy,
+) -> tuple[_IntPND, _FloatND, _FloatND]: ...
+@overload  # (float[:, :], permute_l=False, *, p_indices=True) -> (intp[...], float[...], float[...])
 def lu(
-    a: onp.ToComplex2D,
-    permute_l: Literal[False, 0] = False,
-    overwrite_a: bool = False,
-    check_finite: bool = True,
+    a: onp.ToFloat2D,
+    permute_l: _Falsy = False,
+    overwrite_a: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
     *,
-    p_indices: Literal[True, 1],
-) -> tuple[_Array_i, _Array_fc, _Array_fc]: ...
-@overload
+    p_indices: _Truthy,
+) -> tuple[_IntPND, _FloatND, _FloatND]: ...
+@overload  # (float[:, :], permute_l=True, p_indices=False) -> (intp[...], float[...], float[...])
+def lu(
+    a: onp.ToFloat2D,
+    permute_l: _Truthy,
+    overwrite_a: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+    p_indices: onp.ToBool = False,
+) -> tuple[_FloatND, _FloatND]: ...
+@overload  # (complex[:, :], permute_l=False, p_indices=False) -> (complex[...], complex[...], complex[...])
 def lu(
     a: onp.ToComplex2D,
-    permute_l: Literal[True],
-    overwrite_a: bool = False,
-    check_finite: bool = True,
-    p_indices: bool = False,
-) -> tuple[_Array_fc, _Array_fc]: ...
+    permute_l: _Falsy = False,
+    overwrite_a: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+    p_indices: _Falsy = False,
+) -> tuple[_ComplexND, _ComplexND, _ComplexND]: ...
+@overload  # (complex[:, :], permute_l=False, p_indices=True, /) -> (intp[...], complex[...], complex[...])
+def lu(
+    a: onp.ToComplex2D,
+    permute_l: _Falsy,
+    overwrite_a: onp.ToBool,
+    check_finite: onp.ToBool,
+    p_indices: _Truthy,
+) -> tuple[_IntPND, _ComplexND, _ComplexND]: ...
+@overload  # (complex[:, :], permute_l=False, *, p_indices=True) -> (intp[...], complex[...], complex[...])
+def lu(
+    a: onp.ToComplex2D,
+    permute_l: _Falsy = False,
+    overwrite_a: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+    *,
+    p_indices: _Truthy,
+) -> tuple[_IntPND, _ComplexND, _ComplexND]: ...
+@overload  # (complex[:, :], permute_l=True, p_indices=False) -> (intp[...], complex[...], complex[...])
+def lu(
+    a: onp.ToComplex2D,
+    permute_l: _Truthy,
+    overwrite_a: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+    p_indices: onp.ToBool = False,
+) -> tuple[_ComplexND, _ComplexND]: ...

--- a/scipy-stubs/linalg/_decomp_lu_cython.pyi
+++ b/scipy-stubs/linalg/_decomp_lu_cython.pyi
@@ -1,14 +1,11 @@
-from typing import TypeVar
+from typing import TypeAlias, TypeVar
 
 import numpy as np
 import optype.numpy as onp
 
-# this name was chosen to match `ctypedef fused lapack_t`
-_LapackT = TypeVar("_LapackT", bound=np.float32 | np.float64 | np.complex64 | np.complex128)
+_ST = TypeVar("_ST", bound=np.float32 | np.float64 | np.complex64 | np.complex128)
+_Int1D: TypeAlias = onp.Array1D[np.int32 | np.int64]
 
-def lu_dispatcher(
-    a: onp.ArrayND[_LapackT],
-    u: onp.ArrayND[_LapackT],
-    piv: onp.ArrayND[np.int32 | np.int64],
-    permute_l: bool,
-) -> None: ...
+###
+
+def lu_dispatcher(a: onp.Array2D[_ST], u: onp.Array2D[_ST], piv: _Int1D, permute_l: onp.ToBool) -> None: ...

--- a/scipy-stubs/linalg/_decomp_polar.pyi
+++ b/scipy-stubs/linalg/_decomp_polar.pyi
@@ -1,12 +1,17 @@
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias, TypeVar, overload
 
 import numpy as np
-import numpy.typing as npt
 import optype.numpy as onp
 
 __all__ = ["polar"]
 
-def polar(
-    a: npt.ArrayLike,
-    side: Literal["left", "right"] = "right",
-) -> tuple[onp.Array2D[np.inexact[Any]], onp.Array2D[np.inexact[Any]]]: ...
+_T = TypeVar("_T")
+_Tuple2: TypeAlias = tuple[_T, _T]
+_Side: TypeAlias = Literal["left", "right"]
+
+###
+
+@overload
+def polar(a: onp.ToFloat2D, side: _Side = "right") -> _Tuple2[onp.Array2D[np.floating[Any]]]: ...
+@overload
+def polar(a: onp.ToComplex2D, side: _Side = "right") -> _Tuple2[onp.Array2D[np.inexact[Any]]]: ...

--- a/scipy-stubs/linalg/_decomp_qr.pyi
+++ b/scipy-stubs/linalg/_decomp_qr.pyi
@@ -1,175 +1,371 @@
-from typing import Any, Literal, TypeAlias, overload
+from typing import Any, Literal, TypeAlias, TypeVar, overload
 
 import numpy as np
-import numpy.typing as npt
 import optype.numpy as onp
 
 __all__ = ["qr", "qr_multiply", "rq"]
 
-_Inexact2D: TypeAlias = onp.Array2D[np.inexact[Any]]
+_T = TypeVar("_T")
+_Tuple2: TypeAlias = tuple[_T, _T]
 
-# 5/11 of these overloads could've been avoided with keyword-only parameters; so please use them ;)
-@overload
+_Falsy: TypeAlias = Literal[False, 0]
+_Truthy: TypeAlias = Literal[True, 1]
+
+_Int1D: TypeAlias = onp.Array1D[np.int32 | np.int64]
+_Float1D: TypeAlias = onp.Array1D[np.floating[Any]]
+_Float2D: TypeAlias = onp.Array2D[np.floating[Any]]
+_Complex1D: TypeAlias = onp.Array1D[np.inexact[Any]]
+_Complex2D: TypeAlias = onp.Array2D[np.inexact[Any]]
+
+_Side: TypeAlias = Literal["left", "right"]
+_ModeFullEcon: TypeAlias = Literal["full", "economic"]
+_ModeR: TypeAlias = Literal["r"]
+_ModeRaw: TypeAlias = Literal["raw"]
+
+###
+
+# 2 * (3 + 4 + 4) = 22 overloads (10/22 handle the positional cases of `mode`/`pivoting`)
+@overload  # float, mode: {full, economic}, pivoting: {False}
 def qr(
-    a: onp.ToComplex2D,
-    overwrite_a: bool = False,
-    lwork: int | None = None,
-    mode: Literal["full", "economic"] = "full",
-    pivoting: Literal[False] = False,
-    check_finite: bool = True,
-) -> tuple[_Inexact2D, _Inexact2D]: ...
-@overload
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
+    mode: _ModeFullEcon = "full",
+    pivoting: _Falsy = False,
+    check_finite: onp.ToBool = True,
+) -> _Tuple2[_Float2D]: ...
+@overload  # float, mode: {full, economic}, pivoting: {True}
 def qr(
-    a: onp.ToComplex2D,
-    overwrite_a: bool,
-    lwork: int | None,
-    mode: Literal["r"],
-    pivoting: Literal[False] = False,
-    check_finite: bool = True,
-) -> tuple[_Inexact2D]: ...
-@overload
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool,
+    lwork: onp.ToJustInt | None,
+    mode: _ModeFullEcon,
+    pivoting: _Truthy,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Float2D, _Float2D, _Int1D]: ...
+@overload  # float, mode: {full, economic}, *, pivoting: {True}
 def qr(
-    a: onp.ToComplex2D,
-    overwrite_a: bool = False,
-    lwork: int | None = None,
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
+    mode: _ModeFullEcon = "full",
     *,
-    mode: Literal["r"],
-    pivoting: Literal[False] = False,
-    check_finite: bool = True,
-) -> tuple[_Inexact2D]: ...
-@overload
+    pivoting: _Truthy,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Float2D, _Float2D, _Int1D]: ...
+@overload  # float, mode: {r}, pivoting: {False}
 def qr(
-    a: onp.ToComplex2D,
-    overwrite_a: bool,
-    lwork: int | None,
-    mode: Literal["raw"],
-    pivoting: Literal[False] = False,
-    check_finite: bool = True,
-) -> tuple[tuple[_Inexact2D, _Inexact2D], _Inexact2D]: ...
-@overload
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool,
+    lwork: onp.ToJustInt | None,
+    mode: _ModeR,
+    pivoting: _Falsy = False,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Float2D]: ...
+@overload  # float, mode: {r}, pivoting: {True}
 def qr(
-    a: onp.ToComplex2D,
-    overwrite_a: bool = False,
-    lwork: int | None = None,
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool,
+    lwork: onp.ToJustInt | None,
+    mode: _ModeR,
+    pivoting: _Truthy,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Float2D, _Int1D]: ...
+@overload  # float, *, mode: {r}, pivoting: {False}
+def qr(
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
     *,
-    mode: Literal["raw"],
-    pivoting: Literal[False] = False,
-    check_finite: bool = True,
-) -> tuple[tuple[_Inexact2D, _Inexact2D], _Inexact2D]: ...
-@overload
+    mode: _ModeR,
+    pivoting: _Falsy = False,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Float2D]: ...
+@overload  # float, *, mode: {r}, pivoting: {True}
 def qr(
-    a: onp.ToComplex2D,
-    overwrite_a: bool,
-    lwork: int | None,
-    mode: Literal["full", "economic"],
-    pivoting: Literal[True],
-    check_finite: bool = True,
-) -> tuple[_Inexact2D, _Inexact2D, onp.Array1D[np.int_]]: ...
-@overload
-def qr(
-    a: onp.ToComplex2D,
-    overwrite_a: bool = False,
-    lwork: int | None = None,
-    mode: Literal["full", "economic"] = "full",
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
     *,
-    pivoting: Literal[True],
-    check_finite: bool = True,
-) -> tuple[_Inexact2D, _Inexact2D, onp.Array1D[np.int_]]: ...
-@overload
+    mode: _ModeR,
+    pivoting: _Truthy,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Float2D, _Int1D]: ...
+@overload  # float, mode: {raw}, pivoting: {False}
 def qr(
-    a: onp.ToComplex2D,
-    overwrite_a: bool,
-    lwork: int | None,
-    mode: Literal["r"],
-    pivoting: Literal[True],
-    check_finite: bool = True,
-) -> tuple[_Inexact2D, onp.Array1D[np.int_]]: ...
-@overload
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool,
+    lwork: onp.ToJustInt | None,
+    mode: _ModeRaw,
+    pivoting: _Falsy = False,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Tuple2[_Float2D], _Float2D]: ...
+@overload  # float, mode: {raw}, pivoting: {True}
 def qr(
-    a: onp.ToComplex2D,
-    overwrite_a: bool = False,
-    lwork: int | None = None,
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool,
+    lwork: onp.ToJustInt | None,
+    mode: _ModeRaw,
+    pivoting: _Truthy,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Tuple2[_Float2D], _Float2D, _Int1D]: ...
+@overload  # float, *, mode: {raw}, pivoting: {False}
+def qr(
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
     *,
-    mode: Literal["r"],
-    pivoting: Literal[True],
-    check_finite: bool = True,
-) -> tuple[_Inexact2D, onp.Array1D[np.int_]]: ...
-@overload
+    mode: _ModeRaw,
+    pivoting: _Falsy = False,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Tuple2[_Float2D], _Float2D]: ...
+@overload  # float, *, mode: {raw}, pivoting: {True}
 def qr(
-    a: onp.ToComplex2D,
-    overwrite_a: bool,
-    lwork: int | None,
-    mode: Literal["raw"],
-    pivoting: Literal[True],
-    check_finite: bool = True,
-) -> tuple[tuple[_Inexact2D, _Inexact2D], _Inexact2D, onp.Array1D[np.int_]]: ...
-@overload
-def qr(
-    a: onp.ToComplex2D,
-    overwrite_a: bool = False,
-    lwork: int | None = None,
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
     *,
-    mode: Literal["raw"],
-    pivoting: Literal[True],
-    check_finite: bool = True,
-) -> tuple[tuple[_Inexact2D, _Inexact2D], _Inexact2D, onp.Array1D[np.int_]]: ...
+    mode: _ModeRaw,
+    pivoting: _Truthy,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Tuple2[_Float2D], _Float2D, _Int1D]: ...
+@overload  # complex, mode: {full, economic}, pivoting: {False}
+def qr(
+    a: onp.ToComplex2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
+    mode: _ModeFullEcon = "full",
+    pivoting: _Falsy = False,
+    check_finite: onp.ToBool = True,
+) -> _Tuple2[_Complex2D]: ...
+@overload  # complex, mode: {full, economic}, pivoting: {True}
+def qr(
+    a: onp.ToComplex2D,
+    overwrite_a: onp.ToBool,
+    lwork: onp.ToJustInt | None,
+    mode: _ModeFullEcon,
+    pivoting: _Truthy,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Complex2D, _Complex2D, _Int1D]: ...
+@overload  # complex, mode: {full, economic}, *, pivoting: {True}
+def qr(
+    a: onp.ToComplex2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
+    mode: _ModeFullEcon = "full",
+    *,
+    pivoting: _Truthy,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Complex2D, _Complex2D, _Int1D]: ...
+@overload  # complex, mode: {r}, pivoting: {False}
+def qr(
+    a: onp.ToComplex2D,
+    overwrite_a: onp.ToBool,
+    lwork: onp.ToJustInt | None,
+    mode: _ModeR,
+    pivoting: _Falsy = False,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Complex2D]: ...
+@overload  # complex, mode: {r}, pivoting: {True}
+def qr(
+    a: onp.ToComplex2D,
+    overwrite_a: onp.ToBool,
+    lwork: onp.ToJustInt | None,
+    mode: _ModeR,
+    pivoting: _Truthy,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Complex2D, _Int1D]: ...
+@overload  # complex, *, mode: {r}, pivoting: {False}
+def qr(
+    a: onp.ToComplex2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
+    *,
+    mode: _ModeR,
+    pivoting: _Falsy = False,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Complex2D]: ...
+@overload  # complex, *, mode: {r}, pivoting: {True}
+def qr(
+    a: onp.ToComplex2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
+    *,
+    mode: _ModeR,
+    pivoting: _Truthy,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Complex2D, _Int1D]: ...
+@overload  # complex, mode: {raw}, pivoting: {False}
+def qr(
+    a: onp.ToComplex2D,
+    overwrite_a: onp.ToBool,
+    lwork: onp.ToJustInt | None,
+    mode: _ModeRaw,
+    pivoting: _Falsy = False,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Tuple2[_Complex2D], _Complex2D]: ...
+@overload  # complex, mode: {raw}, pivoting: {True}
+def qr(
+    a: onp.ToComplex2D,
+    overwrite_a: onp.ToBool,
+    lwork: onp.ToJustInt | None,
+    mode: _ModeRaw,
+    pivoting: _Truthy,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Tuple2[_Complex2D], _Complex2D, _Int1D]: ...
+@overload  # complex, *, mode: {raw}, pivoting: {False}
+def qr(
+    a: onp.ToComplex2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
+    *,
+    mode: _ModeRaw,
+    pivoting: _Falsy = False,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Tuple2[_Complex2D], _Complex2D]: ...
+@overload  # complex, *, mode: {raw}, pivoting: {True}
+def qr(
+    a: onp.ToComplex2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
+    *,
+    mode: _ModeRaw,
+    pivoting: _Truthy,
+    check_finite: onp.ToBool = True,
+) -> tuple[_Tuple2[_Complex2D], _Complex2D, _Int1D]: ...
 
 #
-@overload
+@overload  # (float[:, :], float[:], pivoting=False) -> (float[:], float[:, :])
 def qr_multiply(
-    a: onp.ToComplex2D,
-    c: npt.ArrayLike,
-    mode: Literal["left", "right"] = "right",
-    pivoting: Literal[False] = False,
-    conjugate: bool = False,
-    overwrite_a: bool = False,
-    overwrite_c: bool = False,
-) -> tuple[_Inexact2D, _Inexact2D]: ...
-@overload
+    a: onp.ToFloat2D,
+    c: onp.ToFloatStrict1D,
+    mode: _Side = "right",
+    pivoting: _Falsy = False,
+    conjugate: onp.ToBool = False,
+    overwrite_a: onp.ToBool = False,
+    overwrite_c: onp.ToBool = False,
+) -> tuple[_Float1D, _Complex2D]: ...
+@overload  # (float[:, :], float[:, :], pivoting=False) -> (float[:, :], float[:, :])
 def qr_multiply(
-    a: onp.ToComplex2D,
-    c: npt.ArrayLike,
-    mode: Literal["left", "right"],
-    pivoting: Literal[True],
-    conjugate: bool = False,
-    overwrite_a: bool = False,
-    overwrite_c: bool = False,
-) -> tuple[_Inexact2D, _Inexact2D, onp.Array1D[np.int_]]: ...
-@overload
+    a: onp.ToFloat2D,
+    c: onp.ToFloatStrict2D,
+    mode: _Side = "right",
+    pivoting: _Falsy = False,
+    conjugate: onp.ToBool = False,
+    overwrite_a: onp.ToBool = False,
+    overwrite_c: onp.ToBool = False,
+) -> tuple[_Float2D, _Complex2D]: ...
+@overload  # (float[:, :], float[:, :?], pivoting=False) -> (float[:, :?], float[:, :])
 def qr_multiply(
-    a: onp.ToComplex2D,
-    c: npt.ArrayLike,
-    mode: Literal["left", "right"] = "right",
+    a: onp.ToFloat2D,
+    c: onp.ToFloat1D | onp.ToFloat2D,
+    mode: _Side = "right",
+    pivoting: _Falsy = False,
+    conjugate: onp.ToBool = False,
+    overwrite_a: onp.ToBool = False,
+    overwrite_c: onp.ToBool = False,
+) -> tuple[_Float1D | _Float2D, _Complex2D]: ...
+@overload  # (float[:, :], float[:, :?], pivoting=True, /) -> (float[:, :?], float[:, :], int[:])
+def qr_multiply(
+    a: onp.ToFloat2D,
+    c: onp.ToFloat1D | onp.ToFloat2D,
+    mode: _Side,
+    pivoting: _Truthy,
+    conjugate: onp.ToBool = False,
+    overwrite_a: onp.ToBool = False,
+    overwrite_c: onp.ToBool = False,
+) -> tuple[_Float1D | _Float2D, _Float2D, _Int1D]: ...
+@overload  # (float[:, :], float[:, :?], *, pivoting=True) -> (float[:, :?], float[:, :], int[:])
+def qr_multiply(
+    a: onp.ToFloat2D,
+    c: onp.ToFloat1D | onp.ToFloat2D,
+    mode: _Side = "right",
     *,
-    pivoting: Literal[True],
-    conjugate: bool = False,
-    overwrite_a: bool = False,
-    overwrite_c: bool = False,
-) -> tuple[_Inexact2D, _Inexact2D, onp.Array1D[np.int_]]: ...
+    pivoting: _Truthy,
+    conjugate: onp.ToBool = False,
+    overwrite_a: onp.ToBool = False,
+    overwrite_c: onp.ToBool = False,
+) -> tuple[_Float1D | _Float2D, _Float2D, _Int1D]: ...
+@overload  # (complex[:, :], complex[:, :?], pivoting=False) -> (complex[:, :?], complex[:, :])
+def qr_multiply(
+    a: onp.ToComplex2D,
+    c: onp.ToComplex1D | onp.ToComplex2D,
+    mode: _Side = "right",
+    pivoting: _Falsy = False,
+    conjugate: onp.ToBool = False,
+    overwrite_a: onp.ToBool = False,
+    overwrite_c: onp.ToBool = False,
+) -> tuple[_Complex1D | _Complex2D, _Complex2D]: ...
+@overload  # (complex[:, :], complex[:, :?], pivoting=True, /) -> (complex[:, :?], complex[:, :], int[:])
+def qr_multiply(
+    a: onp.ToComplex2D,
+    c: onp.ToComplex1D | onp.ToComplex2D,
+    mode: _Side,
+    pivoting: _Truthy,
+    conjugate: onp.ToBool = False,
+    overwrite_a: onp.ToBool = False,
+    overwrite_c: onp.ToBool = False,
+) -> tuple[_Complex1D | _Complex2D, _Complex2D, _Int1D]: ...
+@overload  # (complex[:, :], complex[:, :?], *, pivoting=True) -> (complex[:, :?], complex[:, :], int[:])
+def qr_multiply(
+    a: onp.ToComplex2D,
+    c: onp.ToComplex1D | onp.ToComplex2D,
+    mode: _Side = "right",
+    *,
+    pivoting: _Truthy,
+    conjugate: onp.ToBool = False,
+    overwrite_a: onp.ToBool = False,
+    overwrite_c: onp.ToBool = False,
+) -> tuple[_Complex1D | _Complex2D, _Complex2D, _Int1D]: ...
 
 #
-@overload
+@overload  # (float[:, :], mode: {"full", "economic"}) -> (float[:, :], float[:, :])
 def rq(
-    a: onp.ToComplex2D,
-    overwrite_a: bool = False,
-    lwork: int | None = None,
-    mode: Literal["full", "economic"] = "full",
-    check_finite: bool = True,
-) -> tuple[_Inexact2D, _Inexact2D]: ...
-@overload
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
+    mode: _ModeFullEcon = "full",
+    check_finite: onp.ToBool = True,
+) -> tuple[_Float2D, _Float2D]: ...
+@overload  # (float[:, :], mode: {"r"}, /) -> float[:, :]
 def rq(
-    a: onp.ToComplex2D,
-    overwrite_a: bool,
-    lwork: int | None,
-    mode: Literal["r"],
-    check_finite: bool = True,
-) -> _Inexact2D: ...
-@overload
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool,
+    lwork: onp.ToJustInt | None,
+    mode: _ModeR,
+    check_finite: onp.ToBool = True,
+) -> _Float2D: ...
+@overload  # (float[:, :], *, mode: {"r"}) -> float[:, :]
 def rq(
-    a: onp.ToComplex2D,
-    overwrite_a: bool = False,
-    lwork: int | None = None,
+    a: onp.ToFloat2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
     *,
-    mode: Literal["r"],
-    check_finite: bool = True,
-) -> _Inexact2D: ...
+    mode: _ModeR,
+    check_finite: onp.ToBool = True,
+) -> _Float2D: ...
+@overload  # (complex[:, :], mode: {"full", "economic"}) -> (complex[:, :], complex[:, :])
+def rq(
+    a: onp.ToComplex2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
+    mode: _ModeFullEcon = "full",
+    check_finite: onp.ToBool = True,
+) -> _Tuple2[_Complex2D]: ...
+@overload  # (complex[:, :], mode: {"r"}, /) -> complex[:, :]
+def rq(
+    a: onp.ToComplex2D,
+    overwrite_a: onp.ToBool,
+    lwork: onp.ToJustInt | None,
+    mode: _ModeR,
+    check_finite: onp.ToBool = True,
+) -> _Complex2D: ...
+@overload  # (complex[:, :], *, mode: {"r"}) -> complex[:, :]
+def rq(
+    a: onp.ToComplex2D,
+    overwrite_a: onp.ToBool = False,
+    lwork: onp.ToJustInt | None = None,
+    *,
+    mode: _ModeR,
+    check_finite: onp.ToBool = True,
+) -> _Complex2D: ...

--- a/scipy-stubs/linalg/_decomp_qz.pyi
+++ b/scipy-stubs/linalg/_decomp_qz.pyi
@@ -1,31 +1,104 @@
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias
+from typing import Any, Literal, TypeAlias, TypeVar, overload
 
 import numpy as np
-import numpy.typing as npt
 import optype.numpy as onp
 
 __all__ = ["ordqz", "qz"]
 
-_Array_fc_1d: TypeAlias = onp.Array2D[np.inexact[Any]]
-_Array_fc_2d: TypeAlias = onp.Array2D[np.inexact[Any]]
+_T1 = TypeVar("_T1")
+_T2 = TypeVar("_T2")
+_Tuple4: TypeAlias = tuple[_T2, _T2, _T2, _T2]
+_Tuple222: TypeAlias = tuple[_T2, _T2, _T1, _T1, _T2, _T2]
 
+_Float1D: TypeAlias = onp.Array1D[np.floating[Any]]
+_Float2D: TypeAlias = onp.Array2D[np.floating[Any]]
+_Complex1D: TypeAlias = onp.Array1D[np.complexfloating[Any, Any]]
+_Complex2D: TypeAlias = onp.Array2D[np.complexfloating[Any, Any]]
+_Inexact1D: TypeAlias = onp.Array1D[np.inexact[Any]]
+_Inexact2D: TypeAlias = onp.Array2D[np.inexact[Any]]
+
+_OutputReal: TypeAlias = Literal["real", "r"]
+_OutputComplex: TypeAlias = Literal["complex", "c"]
+
+_Sort: TypeAlias = Literal["lhp", "rhp", "iuc", "ouc"] | Callable[[float, float], onp.ToBool]
+
+###
+
+# NOTE: `sort` will raise `ValueError` if not `None`.
+@overload  # float, {"real"}
 def qz(
-    A: npt.ArrayLike,
-    B: npt.ArrayLike,
-    output: Literal["real", "complex"] = "real",
-    lwork: int | None = None,
-    sort: None = None,  # disabled for now
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> tuple[_Array_fc_2d, _Array_fc_2d, _Array_fc_2d, _Array_fc_2d]: ...
+    A: onp.ToFloat2D,
+    B: onp.ToFloat2D,
+    output: _OutputReal = "real",
+    lwork: onp.ToJustInt | None = None,
+    sort: None = None,
+    overwrite_a: onp.ToBool = False,
+    overwrite_b: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Tuple4[_Float2D]: ...
+@overload  # complex, {"real"}
+def qz(
+    A: onp.ToComplex2D,
+    B: onp.ToComplex2D,
+    output: _OutputReal = "real",
+    lwork: onp.ToJustInt | None = None,
+    sort: None = None,
+    overwrite_a: onp.ToBool = False,
+    overwrite_b: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Tuple4[_Inexact2D]: ...
+@overload  # complex, {"complex"}
+def qz(
+    A: onp.ToComplex2D,
+    B: onp.ToComplex2D,
+    output: _OutputComplex,
+    lwork: onp.ToJustInt | None = None,
+    sort: None = None,
+    overwrite_a: onp.ToBool = False,
+    overwrite_b: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Tuple4[_Complex2D]: ...
+
+#
+@overload  # float, {"real"}
 def ordqz(
-    A: npt.ArrayLike,
-    B: npt.ArrayLike,
-    sort: Literal["lhp", "rhp", "iuc", "ouc"] | Callable[[float, float], bool] = "lhp",
-    output: Literal["real", "complex"] = "real",
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> tuple[_Array_fc_2d, _Array_fc_2d, _Array_fc_1d, _Array_fc_1d, _Array_fc_2d, _Array_fc_2d]: ...
+    A: onp.ToFloat2D,
+    B: onp.ToFloat2D,
+    sort: _Sort = "lhp",
+    output: _OutputReal = "real",
+    overwrite_a: onp.ToBool = False,
+    overwrite_b: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Tuple222[_Float2D, _Float1D]: ...
+@overload  # complex, {"real"}
+def ordqz(
+    A: onp.ToComplex2D,
+    B: onp.ToComplex2D,
+    sort: _Sort = "lhp",
+    output: _OutputReal = "real",
+    overwrite_a: onp.ToBool = False,
+    overwrite_b: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Tuple222[_Inexact2D, _Inexact1D]: ...
+@overload  # complex, {"complex"} (positional)
+def ordqz(
+    A: onp.ToComplex2D,
+    B: onp.ToComplex2D,
+    sort: _Sort,
+    output: _OutputComplex,
+    overwrite_a: onp.ToBool = False,
+    overwrite_b: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Tuple222[_Complex2D, _Complex1D]: ...
+@overload  # complex, {"complex"} (keyword)
+def ordqz(
+    A: onp.ToComplex2D,
+    B: onp.ToComplex2D,
+    sort: _Sort = "lhp",
+    *,
+    output: _OutputComplex,
+    overwrite_a: onp.ToBool = False,
+    overwrite_b: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _Tuple222[_Complex2D, _Complex1D]: ...

--- a/scipy-stubs/linalg/_decomp_schur.pyi
+++ b/scipy-stubs/linalg/_decomp_schur.pyi
@@ -1,32 +1,83 @@
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias, overload
+from typing import Any, Literal, TypeAlias, TypeVar, overload
 
 import numpy as np
-import numpy.typing as npt
 import optype.numpy as onp
 
 __all__ = ["rsf2csf", "schur"]
 
-_Array_fc_2d: TypeAlias = onp.Array2D[np.inexact[Any]]
-_Array_c_2d: TypeAlias = onp.Array2D[np.complexfloating[Any, Any]]
+_T = TypeVar("_T")
+_Tuple2: TypeAlias = tuple[_T, _T]
+_Tuple2i: TypeAlias = tuple[_T, _T, int]
 
-@overload
+_Float2D: TypeAlias = onp.Array2D[np.floating[Any]]
+_Complex2D: TypeAlias = onp.Array2D[np.complexfloating[Any, Any]]
+_Inexact2D: TypeAlias = onp.Array2D[np.inexact[Any]]
+
+_OutputReal: TypeAlias = Literal["real", "r"]
+_OutputComplex: TypeAlias = Literal["complex", "c"]
+
+_Sort: TypeAlias = Literal["lhp", "rhp", "iuc", "ouc"] | Callable[[float, float], onp.ToBool]
+
+###
+
+@overload  # float, output: {"real"}, sort: _Sort (positional)
 def schur(
-    a: npt.ArrayLike,
-    output: Literal["real", "complex"] = "real",
-    lwork: int | None = None,
-    overwrite_a: bool = False,
+    a: onp.ToFloat2D,
+    output: _OutputReal = "real",
+    lwork: onp.ToJustInt | None = None,
+    overwrite_a: onp.ToBool = False,
     sort: None = None,
-    check_finite: bool = True,
-) -> tuple[_Array_fc_2d, _Array_fc_2d]: ...
-@overload
+    check_finite: onp.ToBool = True,
+) -> _Tuple2[_Float2D]: ...
+@overload  # float, output: {"real"}, sort: _Sort (keyword)
 def schur(
-    a: npt.ArrayLike,
-    output: Literal["real", "complex"] = "real",
-    lwork: int | None = None,
-    overwrite_a: bool = False,
+    a: onp.ToFloat2D,
+    output: _OutputReal = "real",
+    lwork: onp.ToJustInt | None = None,
+    overwrite_a: onp.ToBool = False,
     *,
-    sort: Literal["lhp", "rhp", "iuc", "ouc"] | Callable[[float, float], bool],
-    check_finite: bool = True,
-) -> tuple[_Array_fc_2d, _Array_fc_2d, int]: ...
-def rsf2csf(T: npt.ArrayLike, Z: npt.ArrayLike, check_finite: bool = True) -> tuple[_Array_c_2d, _Array_c_2d]: ...
+    sort: _Sort,
+    check_finite: onp.ToBool = True,
+) -> _Tuple2i[_Inexact2D]: ...
+@overload  # complex, output: {"real"}, sort: _Sort (positional)
+def schur(
+    a: onp.ToComplex2D,
+    output: _OutputReal = "real",
+    lwork: onp.ToJustInt | None = None,
+    overwrite_a: onp.ToBool = False,
+    sort: None = None,
+    check_finite: onp.ToBool = True,
+) -> _Tuple2[_Inexact2D]: ...
+@overload  # complex, output: {"real"}, sort: _Sort (keyword)
+def schur(
+    a: onp.ToComplex2D,
+    output: _OutputReal = "real",
+    lwork: onp.ToJustInt | None = None,
+    overwrite_a: onp.ToBool = False,
+    *,
+    sort: _Sort,
+    check_finite: onp.ToBool = True,
+) -> _Tuple2i[_Inexact2D]: ...
+@overload  # complex, output: {"complex"}, sort: _Sort (positional)
+def schur(
+    a: onp.ToComplex2D,
+    output: _OutputComplex,
+    lwork: onp.ToJustInt | None = None,
+    overwrite_a: onp.ToBool = False,
+    sort: None = None,
+    check_finite: onp.ToBool = True,
+) -> _Tuple2[_Complex2D]: ...
+@overload  # complex, output: {"complex"}, sort: _Sort (keyword)
+def schur(
+    a: onp.ToComplex2D,
+    output: _OutputComplex,
+    lwork: onp.ToJustInt | None = None,
+    overwrite_a: onp.ToBool = False,
+    *,
+    sort: _Sort,
+    check_finite: onp.ToBool = True,
+) -> _Tuple2i[_Complex2D]: ...
+
+#
+def rsf2csf(T: onp.ToFloat2D, Z: onp.ToComplex2D, check_finite: onp.ToBool = True) -> tuple[_Complex2D, _Complex2D]: ...

--- a/scipy-stubs/linalg/_decomp_update.pyi
+++ b/scipy-stubs/linalg/_decomp_update.pyi
@@ -1,37 +1,81 @@
-from typing import Literal, TypeAlias
+from typing import Literal, TypeAlias, overload
 
 import numpy as np
-import numpy.typing as npt
 import optype.numpy as onp
 
 __all__ = ["qr_delete", "qr_insert", "qr_update"]
 
+_Float2D: TypeAlias = onp.Array2D[np.float32 | np.float64]
+_FloatQR: TypeAlias = tuple[_Float2D, _Float2D]
+
+_Complex2D: TypeAlias = onp.Array2D[np.complex64 | np.complex128]
+_ComplexQR: TypeAlias = _FloatQR | tuple[_Complex2D, _Complex2D]
+
 _Which: TypeAlias = Literal["row", "col"]
 
+###
+
+@overload
 def qr_delete(
-    Q: npt.ArrayLike,
-    R: npt.ArrayLike,
-    k: int,
-    p: int = 1,
+    Q: onp.ToFloat2D,
+    R: onp.ToFloat2D,
+    k: onp.ToJustInt,
+    p: onp.ToJustInt = 1,
     which: _Which = "row",
-    overwrite_qr: bool = False,
-    check_finite: bool = True,
-) -> tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]: ...
+    overwrite_qr: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _FloatQR: ...
+@overload
+def qr_delete(
+    Q: onp.ToComplex2D,
+    R: onp.ToComplex2D,
+    k: onp.ToJustInt,
+    p: onp.ToJustInt = 1,
+    which: _Which = "row",
+    overwrite_qr: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _ComplexQR: ...
+
+#
+@overload
 def qr_insert(
-    Q: npt.ArrayLike,
-    R: npt.ArrayLike,
-    u: npt.ArrayLike,
-    k: int,
+    Q: onp.ToFloat2D,
+    R: onp.ToFloat2D,
+    u: onp.ToFloat1D | onp.ToFloat2D,
+    k: onp.ToJustInt,
     which: _Which = "row",
-    rcond: float | None = None,
-    overwrite_qru: bool = False,
-    check_finite: bool = True,
-) -> tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]: ...
+    rcond: onp.ToFloat | None = None,
+    overwrite_qru: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _FloatQR: ...
+@overload
+def qr_insert(
+    Q: onp.ToComplex2D,
+    R: onp.ToComplex2D,
+    u: onp.ToComplex1D | onp.ToComplex2D,
+    k: onp.ToJustInt,
+    which: _Which = "row",
+    rcond: onp.ToFloat | None = None,
+    overwrite_qru: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _ComplexQR: ...
+
+#
+@overload
 def qr_update(
-    Q: npt.ArrayLike,
-    R: npt.ArrayLike,
-    u: npt.ArrayLike,
-    v: npt.ArrayLike,
-    overwrite_qruv: bool = False,
-    check_finite: bool = True,
-) -> tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]: ...
+    Q: onp.ToFloat2D,
+    R: onp.ToFloat2D,
+    u: onp.ToFloat1D | onp.ToFloat2D,
+    v: onp.ToFloat1D | onp.ToFloat2D,
+    overwrite_qruv: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _FloatQR: ...
+@overload
+def qr_update(
+    Q: onp.ToComplex2D,
+    R: onp.ToComplex2D,
+    u: onp.ToComplex1D | onp.ToComplex2D,
+    v: onp.ToComplex1D | onp.ToComplex2D,
+    overwrite_qruv: onp.ToBool = False,
+    check_finite: onp.ToBool = True,
+) -> _ComplexQR: ...

--- a/scipy-stubs/linalg/decomp.pyi
+++ b/scipy-stubs/linalg/decomp.pyi
@@ -2,6 +2,8 @@
 
 from typing_extensions import deprecated
 
+import numpy as np
+
 __all__ = [
     "LinAlgError",
     "cdf2rdf",
@@ -19,23 +21,12 @@ __all__ = [
 ]
 
 @deprecated("will be removed in SciPy v2.0.0")
-class LinAlgError(Exception): ...
+class LinAlgError(np.linalg.LinAlgError): ...
 
 @deprecated("will be removed in SciPy v2.0.0")
-def get_lapack_funcs(
-    names: object,
-    arrays: object = ...,
-    dtype: object = ...,
-    ilp64: object = ...,
-) -> object: ...
+def get_lapack_funcs(names: object, arrays: object = ..., dtype: object = ..., ilp64: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
-def norm(
-    a: object,
-    ord: object = ...,
-    axis: object = ...,
-    keepdims: object = ...,
-    check_finite: object = ...,
-) -> object: ...
+def norm(a: object, ord: object = ..., axis: object = ..., keepdims: object = ..., check_finite: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def cdf2rdf(w: object, v: object) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
@@ -128,9 +119,4 @@ def eigvalsh(
     driver: object = ...,
 ) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
-def hessenberg(
-    a: object,
-    calc_q: object = ...,
-    overwrite_a: object = ...,
-    check_finite: object = ...,
-) -> object: ...
+def hessenberg(a: object, calc_q: object = ..., overwrite_a: object = ..., check_finite: object = ...) -> object: ...

--- a/scipy-stubs/linalg/decomp_cholesky.pyi
+++ b/scipy-stubs/linalg/decomp_cholesky.pyi
@@ -2,45 +2,22 @@
 
 from typing_extensions import deprecated
 
+import numpy as np
+
 __all__ = ["LinAlgError", "cho_factor", "cho_solve", "cho_solve_banded", "cholesky", "cholesky_banded", "get_lapack_funcs"]
 
 @deprecated("will be removed in SciPy v2.0.0")
-class LinAlgError(Exception): ...
+class LinAlgError(np.linalg.LinAlgError): ...
 
 @deprecated("will be removed in SciPy v2.0.0")
-def get_lapack_funcs(
-    names: object,
-    arrays: object = ...,
-    dtype: object = ...,
-    ilp64: object = ...,
-) -> object: ...
+def get_lapack_funcs(names: object, arrays: object = ..., dtype: object = ..., ilp64: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def cholesky(a: object, lower: object = ..., overwrite_a: object = ..., check_finite: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
-def cho_factor(
-    a: object,
-    lower: object = ...,
-    overwrite_a: object = ...,
-    check_finite: object = ...,
-) -> object: ...
+def cho_factor(a: object, lower: object = ..., overwrite_a: object = ..., check_finite: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
-def cho_solve(
-    c_and_lower: object,
-    b: object,
-    overwrite_b: object = ...,
-    check_finite: object = ...,
-) -> object: ...
+def cho_solve(c_and_lower: object, b: object, overwrite_b: object = ..., check_finite: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
-def cholesky_banded(
-    ab: object,
-    overwrite_ab: object = ...,
-    lower: object = ...,
-    check_finite: object = ...,
-) -> object: ...
+def cholesky_banded(ab: object, overwrite_ab: object = ..., lower: object = ..., check_finite: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
-def cho_solve_banded(
-    cb_and_lower: object,
-    b: object,
-    overwrite_b: object = ...,
-    check_finite: object = ...,
-) -> object: ...
+def cho_solve_banded(cb_and_lower: object, b: object, overwrite_b: object = ..., check_finite: object = ...) -> object: ...

--- a/scipy-stubs/linalg/decomp_lu.pyi
+++ b/scipy-stubs/linalg/decomp_lu.pyi
@@ -2,18 +2,15 @@
 
 from typing_extensions import deprecated
 
+from ._misc import LinAlgWarning as _LinAlgWarning
+
 __all__ = ["LinAlgWarning", "get_lapack_funcs", "lu", "lu_factor", "lu_solve"]
 
 @deprecated("will be removed in SciPy v2.0.0")
-class LinAlgWarning(RuntimeWarning): ...
+class LinAlgWarning(_LinAlgWarning): ...
 
 @deprecated("will be removed in SciPy v2.0.0")
-def get_lapack_funcs(
-    names: object,
-    arrays: object = ...,
-    dtype: object = ...,
-    ilp64: object = ...,
-) -> object: ...
+def get_lapack_funcs(names: object, arrays: object = ..., dtype: object = ..., ilp64: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def lu(
     a: object,
@@ -23,11 +20,7 @@ def lu(
     p_indices: object = ...,
 ) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
-def lu_factor(
-    a: object,
-    overwrite_a: object = ...,
-    check_finite: object = ...,
-) -> object: ...
+def lu_factor(a: object, overwrite_a: object = ..., check_finite: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def lu_solve(
     lu_and_piv: object,

--- a/scipy-stubs/linalg/decomp_qr.pyi
+++ b/scipy-stubs/linalg/decomp_qr.pyi
@@ -5,12 +5,7 @@ from typing_extensions import deprecated
 __all__ = ["get_lapack_funcs", "qr", "qr_multiply", "rq"]
 
 @deprecated("will be removed in SciPy v2.0.0")
-def get_lapack_funcs(
-    names: object,
-    arrays: object = ...,
-    dtype: object = ...,
-    ilp64: object = ...,
-) -> object: ...
+def get_lapack_funcs(names: object, arrays: object = ..., dtype: object = ..., ilp64: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def qr(
     a: object,
@@ -31,10 +26,4 @@ def qr_multiply(
     overwrite_c: object = ...,
 ) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
-def rq(
-    a: object,
-    overwrite_a: object = ...,
-    lwork: object = ...,
-    mode: object = ...,
-    check_finite: object = ...,
-) -> object: ...
+def rq(a: object, overwrite_a: object = ..., lwork: object = ..., mode: object = ..., check_finite: object = ...) -> object: ...

--- a/scipy-stubs/linalg/decomp_schur.pyi
+++ b/scipy-stubs/linalg/decomp_schur.pyi
@@ -2,18 +2,15 @@
 
 from typing_extensions import deprecated
 
+import numpy as np
+
 __all__ = ["LinAlgError", "eigvals", "get_lapack_funcs", "norm", "rsf2csf", "schur"]
 
 @deprecated("will be removed in SciPy v2.0.0")
-class LinAlgError(Exception): ...
+class LinAlgError(np.linalg.LinAlgError): ...
 
 @deprecated("will be removed in SciPy v2.0.0")
-def get_lapack_funcs(
-    names: object,
-    arrays: object = ...,
-    dtype: object = ...,
-    ilp64: object = ...,
-) -> object: ...
+def get_lapack_funcs(names: object, arrays: object = ..., dtype: object = ..., ilp64: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def eigvals(
     a: object,

--- a/scipy-stubs/linalg/decomp_svd.pyi
+++ b/scipy-stubs/linalg/decomp_svd.pyi
@@ -2,18 +2,15 @@
 
 from typing_extensions import deprecated
 
+import numpy as np
+
 __all__ = ["LinAlgError", "diagsvd", "get_lapack_funcs", "null_space", "orth", "subspace_angles", "svd", "svdvals"]
 
 @deprecated("will be removed in SciPy v2.0.0")
-class LinAlgError(Exception): ...
+class LinAlgError(np.linalg.LinAlgError): ...
 
 @deprecated("will be removed in SciPy v2.0.0")
-def get_lapack_funcs(
-    names: object,
-    arrays: object = ...,
-    dtype: object = ...,
-    ilp64: object = ...,
-) -> object: ...
+def get_lapack_funcs(names: object, arrays: object = ..., dtype: object = ..., ilp64: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def diagsvd(s: object, M: object, N: object) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")


### PR DESCRIPTION
This improves the following public `scipy.linalg` function signatures:

- `cholesky[_banded]`
- `cho_solve[_banded]`
- `cho_factor`
- `eig[_banded]`
- `eigvals[_banded]`
- `eigh[_tridiagonal]`
- `eigvalsh[_tridiagonal]`
- `cossin`
- `hessenberg`
- `ldl`
- `lu`
- `lu_factor`
- `lu_solve`
- `polar`
- `qr`
- `qr_multiply`
- `rq`
- `qz`
- `ordqz`
- `schur`
- `svd`
- `svdvals`
- `diagsvd`
- `orth`
- `null_spaces`
- `subspace_angles`
- `qr_delete`
- `qr_insert`
- `qr_update`
- `rsf2csf`
- `cdf2rdf`

towards #233