### PR TITLE
✨ `interpolate`: complete `_bsplines` and `_ndbspline`

### DIFF
--- a/scipy-stubs/interpolate/_bsplines.pyi
+++ b/scipy-stubs/interpolate/_bsplines.pyi
@@ -1,47 +1,102 @@
+from typing import Any, Generic, Literal, TypeAlias, TypeVar
+from typing_extensions import Self
+
+import numpy as np
+import optype as op
+import optype.numpy as onp
 from scipy._typing import Untyped
+from scipy.interpolate import CubicSpline
+from scipy.sparse import csr_array
 
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline", "make_smoothing_spline"]
 
-class BSpline:
-    k: Untyped
-    c: Untyped
-    t: Untyped
-    extrapolate: Untyped
-    axis: Untyped
+_Extrapolate: TypeAlias = Literal["periodic"] | bool
+_BCType: TypeAlias = Literal["not-a-knot", "natural", "clamped", "periodic"]
+
+_SCT_co = TypeVar("_SCT_co", bound=np.floating[Any], default=np.floating[Any], covariant=True)
+
+###
+
+class BSpline(Generic[_SCT_co]):
+    t: onp.Array1D[np.float64]
+    c: onp.Array[onp.AtLeast1D, _SCT_co]
+    k: int
+    extrapolate: _Extrapolate
+    axis: int
+
     @property
     def tck(self, /) -> Untyped: ...
-    def __init__(self, /, t: Untyped, c: Untyped, k: Untyped, extrapolate: bool = True, axis: int = 0) -> None: ...
-    def __call__(self, /, x: Untyped, nu: int = 0, extrapolate: Untyped | None = None) -> Untyped: ...
-    def derivative(self, /, nu: int = 1) -> Untyped: ...
-    def antiderivative(self, /, nu: int = 1) -> Untyped: ...
-    def integrate(self, /, a: Untyped, b: Untyped, extrapolate: Untyped | None = None) -> Untyped: ...
-    def insert_knot(self, /, x: Untyped, m: int = 1) -> Untyped: ...
-    @classmethod
-    def basis_element(cls, t: Untyped, extrapolate: bool = True) -> Untyped: ...
-    @classmethod
-    def design_matrix(cls, x: Untyped, t: Untyped, k: Untyped, extrapolate: bool = False) -> Untyped: ...
-    @classmethod
-    def from_power_basis(cls, pp: Untyped, bc_type: str = "not-a-knot") -> Untyped: ...
-    @classmethod
-    def construct_fast(cls, t: Untyped, c: Untyped, k: Untyped, extrapolate: bool = True, axis: int = 0) -> Untyped: ...
 
+    #
+    def __init__(
+        self,
+        /,
+        t: onp.ToFloat1D,
+        c: onp.ToFloatND,
+        k: op.CanIndex,
+        extrapolate: _Extrapolate = True,
+        axis: op.CanIndex = 0,
+    ) -> None: ...
+    def __call__(self, /, x: onp.ToFloatND, nu: int = 0, extrapolate: _Extrapolate | None = None) -> onp.ArrayND[_SCT_co]: ...
+
+    #
+    def derivative(self, /, nu: int = 1) -> Self: ...
+    def antiderivative(self, /, nu: int = 1) -> Self: ...
+    def integrate(self, /, a: onp.ToFloat, b: onp.ToFloat, extrapolate: _Extrapolate | None = None) -> onp.ArrayND[_SCT_co]: ...
+    def insert_knot(self, /, x: onp.ToFloat, m: op.CanIndex = 1) -> Untyped: ...
+
+    #
+    @classmethod
+    def basis_element(cls, t: onp.ToFloat1D, extrapolate: _Extrapolate = True) -> Self: ...
+    @classmethod
+    def design_matrix(
+        cls,
+        x: onp.ToFloat1D,
+        t: onp.ToFloat1D,
+        k: op.CanIndex,
+        extrapolate: _Extrapolate = False,
+    ) -> csr_array: ...
+    @classmethod
+    def from_power_basis(cls, pp: CubicSpline, bc_type: _BCType = "not-a-knot") -> Self: ...
+    @classmethod
+    def construct_fast(
+        cls,
+        t: onp.Array1D[np.float64],
+        c: onp.Array[onp.AtLeast1D, _SCT_co],
+        k: int,
+        extrapolate: _Extrapolate = True,
+        axis: int = 0,
+    ) -> Self: ...
+
+#
 def make_interp_spline(
-    x: Untyped,
-    y: Untyped,
-    k: int = 3,
-    t: Untyped | None = None,
-    bc_type: Untyped | None = None,
-    axis: int = 0,
-    check_finite: bool = True,
-) -> Untyped: ...
+    x: onp.ToFloat1D,
+    y: onp.ToFloatND,
+    k: op.CanIndex = 3,
+    t: onp.ToFloat1D | None = None,
+    bc_type: tuple[onp.ToFloat, onp.ToFloat] | _BCType | None = None,
+    axis: op.CanIndex = 0,
+    check_finite: onp.ToBool = True,
+) -> BSpline: ...
+
+#
 def make_lsq_spline(
-    x: Untyped,
-    y: Untyped,
-    t: Untyped,
-    k: int = 3,
-    w: Untyped | None = None,
-    axis: int = 0,
-    check_finite: bool = True,
-) -> Untyped: ...
-def make_smoothing_spline(x: Untyped, y: Untyped, w: Untyped | None = None, lam: Untyped | None = None) -> Untyped: ...
-def fpcheck(x: Untyped, t: Untyped, k: Untyped) -> None: ...  # undocumented
+    x: onp.ToFloat1D,
+    y: onp.ToFloatND,
+    t: onp.ToFloat1D,
+    k: op.CanIndex = 3,
+    w: onp.ToFloat1D | None = None,
+    axis: op.CanIndex = 0,
+    check_finite: onp.ToBool = True,
+) -> BSpline: ...
+
+#
+def make_smoothing_spline(
+    x: onp.ToFloat1D,
+    y: onp.ToFloat1D,
+    w: onp.ToFloat1D | None = None,
+    lam: onp.ToFloat | None = None,
+) -> BSpline: ...
+
+#
+def fpcheck(x: onp.ToFloat1D, t: onp.ToFloat1D, k: onp.ToJustInt) -> None: ...  # undocumented

--- a/scipy-stubs/interpolate/_ndbspline.pyi
+++ b/scipy-stubs/interpolate/_ndbspline.pyi
@@ -1,23 +1,50 @@
-from scipy._typing import Untyped
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import optype as op
+import optype.numpy as onp
+from scipy.sparse import csr_array
 
 __all__ = ["NdBSpline"]
 
 class NdBSpline:
-    k: Untyped
-    t: Untyped
-    c: Untyped
-    extrapolate: Untyped
+    t: tuple[onp.Array1D[np.float64]]
+    c: onp.ArrayND[np.float64]
+    k: int
+    extrapolate: bool
 
-    def __init__(self, /, t: Untyped, c: Untyped, k: Untyped, *, extrapolate: bool | None = None) -> None: ...
-    def __call__(self, /, xi: Untyped, *, nu: Untyped | None = None, extrapolate: bool | None = None) -> Untyped: ...
+    def __init__(
+        self,
+        /,
+        t: tuple[onp.ToFloat1D, ...],
+        c: onp.ToFloatND,
+        k: op.CanIndex | tuple[op.CanIndex, ...],
+        *,
+        extrapolate: onp.ToBool | None = None,
+    ) -> None: ...
+    def __call__(
+        self,
+        /,
+        xi: onp.ToFloatND,
+        *,
+        nu: onp.ToFloat1D | None = None,
+        extrapolate: onp.ToBool | None = None,
+    ) -> onp.ArrayND[np.floating[Any]]: ...
     @classmethod
-    def design_matrix(cls, xvals: Untyped, t: Untyped, k: Untyped, extrapolate: bool = True) -> Untyped: ...
+    def design_matrix(
+        cls,
+        xvals: onp.ToFloat2D,
+        t: tuple[onp.ToFloat1D, ...],
+        k: op.CanIndex | tuple[op.CanIndex, ...],
+        extrapolate: onp.ToBool = True,
+    ) -> csr_array: ...
 
 def make_ndbspl(
-    points: Untyped,
-    values: Untyped,
-    k: int = 3,
+    points: tuple[onp.ToFloat1D, ...],
+    values: onp.ToFloatND,
+    k: op.CanIndex | tuple[op.CanIndex, ...] = 3,
     *,
-    solver: Untyped = ...,
-    **solver_args: Untyped,
-) -> Untyped: ...  # undocumented
+    solver: Callable[..., object] = ...,
+    **solver_args: object,
+) -> NdBSpline: ...  # undocumented


### PR DESCRIPTION
This affects the following public `scipy.interpolate` members:

- `NdBSpline`
- `BSpline`
- `make_interp_spline`
- `make_lsq_spline`
- `make_smoothing_spline`

towards #101 (-68)
