### PR TITLE
✨ `interpolate`: complete `RBFInterpolator` and `Rbf`

### DIFF
--- a/scipy-stubs/interpolate/_rbf.pyi
+++ b/scipy-stubs/interpolate/_rbf.pyi
@@ -1,18 +1,43 @@
-from scipy._typing import Untyped
+from collections.abc import Callable
+from typing import Literal, TypeAlias
+
+import numpy as np
+import optype.numpy as onp
 
 __all__ = ["Rbf"]
 
+_Mode: TypeAlias = Literal["1-D", "N-D"]
+_Function: TypeAlias = (
+    Literal["multiquadric", "inverse", "gaussian", "linear", "cubic", "quintic", "thin_plate"]
+    | Callable[[Rbf, float], onp.ToFloat]
+)
+
+###
+
+# legacy
 class Rbf:
-    xi: Untyped
-    N: Untyped
-    mode: Untyped
-    di: Untyped
-    norm: Untyped
-    epsilon: Untyped
-    smooth: Untyped
-    function: Untyped
-    nodes: Untyped
+    N: int
+    di: onp.Array1D[np.float64]
+    xi: onp.Array2D[np.float64]
+    function: _Function
+    epsilon: float
+    smooth: float
+    norm: str | Callable[..., onp.ToFloat2D]
+    mode: _Mode
+    nodes: onp.Array1D[np.float64]
+
     @property
-    def A(self, /) -> Untyped: ...
-    def __init__(self, /, *args: Untyped, **kwargs: Untyped) -> None: ...
-    def __call__(self, /, *args: Untyped) -> Untyped: ...
+    def A(self, /) -> onp.Array2D[np.float64]: ...  # undocumented
+
+    #
+    def __init__(
+        self,
+        /,
+        *args: onp.ToFloat1D,
+        function: _Function = ...,
+        epsilon: onp.ToFloat = ...,
+        smooth: onp.ToFloat = ...,
+        norm: str | Callable[..., onp.ToFloat2D] = ...,
+        mode: _Mode = ...,
+    ) -> None: ...
+    def __call__(self, /, *args: onp.ToFloatND) -> onp.ArrayND[np.float64]: ...

--- a/scipy-stubs/interpolate/_rbfinterp.pyi
+++ b/scipy-stubs/interpolate/_rbfinterp.pyi
@@ -1,26 +1,134 @@
-from scipy._typing import Untyped
+from typing import Generic, Literal, TypeAlias, overload
+from typing_extensions import TypeVar
+
+import numpy as np
+import optype.numpy as onp
 
 __all__ = ["RBFInterpolator"]
 
-class RBFInterpolator:
-    y: Untyped
-    d: Untyped
-    d_shape: Untyped
-    d_dtype: Untyped
-    neighbors: Untyped
-    smoothing: Untyped
-    kernel: Untyped
-    epsilon: Untyped
-    powers: Untyped
+_Kernel: TypeAlias = Literal[
+    "thin_plate_spline",
+    "linear",
+    "cubic",
+    "quintic",
+    "multiquadric",
+    "inverse_multiquadric",
+    "inverse_quadratic",
+    "gaussian",
+]
+
+_ShapeT_co = TypeVar("_ShapeT_co", bound=tuple[int, ...], default=onp.AtLeast1D, covariant=True)
+_SCT_co = TypeVar("_SCT_co", bound=np.float64 | np.complex128, default=np.float64 | np.complex128, covariant=True)
+
+###
+
+class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
+    y: onp.Array2D[np.float64]
+    d: onp.Array[_ShapeT_co, np.float64]
+    d_shape: _ShapeT_co
+    d_dtype: type[float | complex]
+    neighbors: int
+    smoothing: onp.Array1D[np.float64]
+    kernel: _Kernel
+    epsilon: float
+    powers: int
+
+    @overload
+    def __init__(
+        self: RBFInterpolator[tuple[int], np.float64],
+        /,
+        y: onp.ToFloat2D,
+        d: onp.ToFloatStrict1D,
+        neighbors: onp.ToJustInt | None = None,
+        smoothing: onp.ToFloat | onp.ToFloat1D = 0.0,
+        kernel: _Kernel = "thin_plate_spline",
+        epsilon: onp.ToFloat | None = None,
+        degree: onp.ToJustInt | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: RBFInterpolator[tuple[int]],
+        /,
+        y: onp.ToFloat2D,
+        d: onp.ToComplexStrict1D,
+        neighbors: onp.ToJustInt | None = None,
+        smoothing: onp.ToFloat | onp.ToFloat1D = 0.0,
+        kernel: _Kernel = "thin_plate_spline",
+        epsilon: onp.ToFloat | None = None,
+        degree: onp.ToJustInt | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: RBFInterpolator[tuple[int, int], np.float64],
+        /,
+        y: onp.ToFloat2D,
+        d: onp.ToFloatStrict2D,
+        neighbors: onp.ToJustInt | None = None,
+        smoothing: onp.ToFloat | onp.ToFloat1D = 0.0,
+        kernel: _Kernel = "thin_plate_spline",
+        epsilon: onp.ToFloat | None = None,
+        degree: onp.ToJustInt | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: RBFInterpolator[tuple[int, int]],
+        /,
+        y: onp.ToFloat2D,
+        d: onp.ToComplexStrict2D,
+        neighbors: onp.ToJustInt | None = None,
+        smoothing: onp.ToFloat | onp.ToFloat1D = 0.0,
+        kernel: _Kernel = "thin_plate_spline",
+        epsilon: onp.ToFloat | None = None,
+        degree: onp.ToJustInt | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: RBFInterpolator[tuple[int, int, int], np.float64],
+        /,
+        y: onp.ToFloat2D,
+        d: onp.ToFloatStrict3D,
+        neighbors: onp.ToJustInt | None = None,
+        smoothing: onp.ToFloat | onp.ToFloat1D = 0.0,
+        kernel: _Kernel = "thin_plate_spline",
+        epsilon: onp.ToFloat | None = None,
+        degree: onp.ToJustInt | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: RBFInterpolator[tuple[int, int, int]],
+        /,
+        y: onp.ToFloat2D,
+        d: onp.ToComplexStrict3D,
+        neighbors: onp.ToJustInt | None = None,
+        smoothing: onp.ToFloat | onp.ToFloat1D = 0.0,
+        kernel: _Kernel = "thin_plate_spline",
+        epsilon: onp.ToFloat | None = None,
+        degree: onp.ToJustInt | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: RBFInterpolator[onp.AtLeast1D, np.float64],
+        /,
+        y: onp.ToFloat2D,
+        d: onp.ToFloatND,
+        neighbors: onp.ToJustInt | None = None,
+        smoothing: onp.ToFloat | onp.ToFloat1D = 0.0,
+        kernel: _Kernel = "thin_plate_spline",
+        epsilon: onp.ToFloat | None = None,
+        degree: onp.ToJustInt | None = None,
+    ) -> None: ...
+    @overload
     def __init__(
         self,
         /,
-        y: Untyped,
-        d: Untyped,
-        neighbors: Untyped | None = None,
-        smoothing: float = 0.0,
-        kernel: str = "thin_plate_spline",
-        epsilon: Untyped | None = None,
-        degree: Untyped | None = None,
+        y: onp.ToFloat2D,
+        d: onp.ToComplexND,
+        neighbors: onp.ToJustInt | None = None,
+        smoothing: onp.ToFloat | onp.ToFloat1D = 0.0,
+        kernel: _Kernel = "thin_plate_spline",
+        epsilon: onp.ToFloat | None = None,
+        degree: onp.ToJustInt | None = None,
     ) -> None: ...
-    def __call__(self, /, x: Untyped) -> Untyped: ...
+
+    # TODO(jorenham): Return `onp.Array[tuple[int, Unpack[_ShapeT_co]], _SCT_co]` once mypy supports it (if ever)
+    def __call__(self, /, x: onp.ToFloat2D) -> onp.ArrayND[_SCT_co]: ...


### PR DESCRIPTION
This affects the following public `scipy.interpolate` classes:

- `RBFInterpolator`
- `Rbf` (legacy)

towards #101 (-32)