### PR TITLE
✨ `interpolate`: complete `_fitpack*` (1/2)

### DIFF
--- a/scipy-stubs/interpolate/_fitpack_impl.pyi
+++ b/scipy-stubs/interpolate/_fitpack_impl.pyi
@@ -1,42 +1,152 @@
+from collections.abc import Sequence
+from typing import Literal, TypeAlias, overload
+from typing_extensions import LiteralString
+
+import numpy as np
+import optype.numpy as onp
 from scipy._typing import Untyped
 
 __all__ = ["bisplev", "bisplrep", "insert", "spalde", "splantider", "splder", "splev", "splint", "splprep", "splrep", "sproot"]
 
+_Falsy: TypeAlias = Literal[False, 0]
+_Truthy: TypeAlias = Literal[True, 1]
+
+_Float: TypeAlias = float | np.float64
+_Float1D: TypeAlias = onp.Array1D[np.float64]
+_FloatND: TypeAlias = onp.ArrayND[np.float64]
+
+_Task: TypeAlias = Literal[-1, 0, 1]
+_Ext: TypeAlias = Literal[0, 1, 2, 3]
+
+_ToTCK: TypeAlias = Sequence[onp.ToFloat1D | onp.ToFloat2D | int]
+# `(t, c, k)`
+_OutTCK: TypeAlias = tuple[_Float1D, _Float1D, int]
+# `([t, c, k], u)`
+_OutTCKU: TypeAlias = tuple[Sequence[_Float1D | list[_Float1D] | int], _Float1D]
+
+###
+
+# NOTE: The docs are incorrect about the return type of `splgrep`
+@overload  # full_output: falsy = ...
 def splprep(
-    x: Untyped,
-    w: Untyped | None = None,
-    u: Untyped | None = None,
-    ub: Untyped | None = None,
-    ue: Untyped | None = None,
+    x: onp.ToFloat2D,
+    w: onp.ToFloat1D | None = None,
+    u: onp.ToFloat1D | None = None,
+    ub: onp.ToFloat | None = None,
+    ue: onp.ToFloat | None = None,
     k: int = 3,
-    task: int = 0,
-    s: Untyped | None = None,
-    t: Untyped | None = None,
-    full_output: int = 0,
-    nest: Untyped | None = None,
-    per: int = 0,
-    quiet: int = 1,
-) -> Untyped: ...
-def splrep(
-    x: Untyped,
-    y: Untyped,
-    w: Untyped | None = None,
-    xb: Untyped | None = None,
-    xe: Untyped | None = None,
+    task: _Task = 0,
+    s: onp.ToFloat | None = None,
+    t: onp.ToFloat1D | None = None,
+    full_output: _Falsy = 0,
+    nest: int | None = None,
+    per: onp.ToBool = 0,
+    quiet: onp.ToBool = 1,
+) -> _OutTCKU: ...
+@overload  # full_output: truthy (positional)
+def splprep(
+    x: onp.ToFloat2D,
+    w: onp.ToFloat1D | None,
+    u: onp.ToFloat1D | None,
+    ub: onp.ToFloat | None,
+    ue: onp.ToFloat | None,
+    k: int,
+    task: _Task,
+    s: onp.ToFloat | None,
+    t: onp.ToFloat1D | None,
+    full_output: _Truthy,
+    nest: int | None = None,
+    per: onp.ToBool = 0,
+    quiet: onp.ToBool = 1,
+) -> tuple[_OutTCKU, _Float, int, LiteralString]: ...
+@overload  # full_output: truthy (keyword)
+def splprep(
+    x: onp.ToFloat2D,
+    w: onp.ToFloat1D | None = None,
+    u: onp.ToFloat1D | None = None,
+    ub: onp.ToFloat | None = None,
+    ue: onp.ToFloat | None = None,
     k: int = 3,
-    task: int = 0,
-    s: Untyped | None = None,
-    t: Untyped | None = None,
-    full_output: int = 0,
-    per: int = 0,
-    quiet: int = 1,
-) -> Untyped: ...
-def splev(x: Untyped, tck: Untyped, der: int = 0, ext: int = 0) -> Untyped: ...
-def splint(a: Untyped, b: Untyped, tck: Untyped, full_output: int = 0) -> Untyped: ...
-def sproot(tck: Untyped, mest: int = 10) -> Untyped: ...
-def spalde(x: Untyped, tck: Untyped) -> Untyped: ...
+    task: _Task = 0,
+    s: onp.ToFloat | None = None,
+    t: onp.ToFloat1D | None = None,
+    *,
+    full_output: _Truthy,
+    nest: int | None = None,
+    per: onp.ToBool = 0,
+    quiet: onp.ToBool = 1,
+) -> tuple[_OutTCKU, _Float, int, LiteralString]: ...
 
 #
+@overload  # full_output: falsy = ...
+def splrep(
+    x: onp.ToFloat1D,
+    y: onp.ToFloat1D,
+    w: onp.ToFloat1D | None = None,
+    xb: onp.ToFloat | None = None,
+    xe: onp.ToFloat | None = None,
+    k: int = 3,
+    task: _Task = 0,
+    s: onp.ToFloat | None = None,
+    t: onp.ToFloat1D | None = None,
+    full_output: _Falsy = 0,
+    per: onp.ToBool = 0,
+    quiet: onp.ToBool = 1,
+) -> _OutTCK: ...
+@overload  # full_output: truthy (positional)
+def splrep(
+    x: onp.ToFloat1D,
+    y: onp.ToFloat1D,
+    w: onp.ToFloat1D | None,
+    xb: onp.ToFloat | None,
+    xe: onp.ToFloat | None,
+    k: int,
+    task: _Task,
+    s: onp.ToFloat | None,
+    t: onp.ToFloat1D | None,
+    full_output: _Truthy,
+    per: onp.ToBool = 0,
+    quiet: onp.ToBool = 1,
+) -> tuple[_OutTCK, _Float, int, LiteralString]: ...
+@overload  # full_output: truthy (keyword)
+def splrep(
+    x: onp.ToFloat1D,
+    y: onp.ToFloat1D,
+    w: onp.ToFloat1D | None = None,
+    xb: onp.ToFloat | None = None,
+    xe: onp.ToFloat | None = None,
+    k: int = 3,
+    task: _Task = 0,
+    s: onp.ToFloat | None = None,
+    t: onp.ToFloat1D | None = None,
+    *,
+    full_output: _Truthy,
+    per: onp.ToBool = 0,
+    quiet: onp.ToBool = 1,
+) -> tuple[_OutTCK, _Float, int, LiteralString]: ...
+
+#
+def splev(x: onp.ToFloatND, tck: _ToTCK, der: int = 0, ext: _Ext = 0) -> _FloatND: ...
+
+#
+@overload  # full_output: falsy
+def splint(a: onp.ToFloat, b: onp.ToFloat, tck: _ToTCK, full_output: _Falsy = 0) -> _Float | list[_Float]: ...
+@overload  # full_output: truthy
+def splint(a: onp.ToFloat, b: onp.ToFloat, tck: _ToTCK, full_output: _Truthy) -> tuple[_Float | list[_Float], _Float1D]: ...
+
+#
+def sproot(tck: _ToTCK, mest: int = 10) -> _Float1D | list[_Float1D]: ...
+
+#
+@overload
+def spalde(x: onp.ToFloatStrict1D, tck: _ToTCK) -> _Float1D: ...
+@overload
+def spalde(x: onp.ToFloatStrict2D, tck: _ToTCK) -> list[_Float1D]: ...
+@overload
+def spalde(x: onp.ToFloat1D | onp.ToFloat2D, tck: _ToTCK) -> _Float1D | list[_Float1D]: ...
+
+#
+# TODO(jorenham): full_output=True
 def bisplrep(
     x: Untyped,
     y: Untyped,
@@ -48,18 +158,28 @@ def bisplrep(
     ye: Untyped | None = None,
     kx: int = 3,
     ky: int = 3,
-    task: int = 0,
+    task: _Task = 0,
     s: Untyped | None = None,
     eps: float = 1e-16,
     tx: Untyped | None = None,
     ty: Untyped | None = None,
-    full_output: int = 0,
+    full_output: _Falsy = 0,
     nxest: Untyped | None = None,
     nyest: Untyped | None = None,
     quiet: int = 1,
 ) -> Untyped: ...
+
+#
 def bisplev(x: Untyped, y: Untyped, tck: Untyped, dx: int = 0, dy: int = 0) -> Untyped: ...
+
+#
 def dblint(xa: Untyped, xb: Untyped, ya: Untyped, yb: Untyped, tck: Untyped) -> Untyped: ...
+
+#
 def insert(x: Untyped, tck: Untyped, m: int = 1, per: int = 0) -> Untyped: ...
+
+#
 def splder(tck: Untyped, n: int = 1) -> Untyped: ...
+
+#
 def splantider(tck: Untyped, n: int = 1) -> Untyped: ...

--- a/scipy-stubs/interpolate/_fitpack_py.pyi
+++ b/scipy-stubs/interpolate/_fitpack_py.pyi
@@ -1,3 +1,58 @@
-from ._fitpack_impl import bisplev, bisplrep, insert, spalde, splantider, splder, splev, splint, splprep, splrep, sproot
+from collections.abc import Sequence
+from typing import Literal, TypeAlias, overload
+
+import numpy as np
+import optype.numpy as onp
+from ._bsplines import BSpline
+from ._fitpack_impl import bisplev, bisplrep, insert, splantider, splder, splprep, splrep
 
 __all__ = ["bisplev", "bisplrep", "insert", "spalde", "splantider", "splder", "splev", "splint", "splprep", "splrep", "sproot"]
+
+_Falsy: TypeAlias = Literal[False, 0]
+_Truthy: TypeAlias = Literal[True, 1]
+
+_Float: TypeAlias = float | np.float64
+_Float1D: TypeAlias = onp.Array1D[np.float64]
+_Float2D: TypeAlias = onp.Array2D[np.float64]
+_FloatND: TypeAlias = onp.ArrayND[np.float64]
+
+_Ext: TypeAlias = Literal[0, 1, 2, 3]
+_ToTCK: TypeAlias = Sequence[onp.ToFloat1D | onp.ToFloat2D | int]
+
+###
+
+# NOTE: The following functions also accept `BSpline` instances, unlike their duals in `_fitpack_impl`.
+
+#
+@overload  # tck: BSpline
+def splev(x: onp.ToFloatND, tck: BSpline, der: int = 0, ext: _Ext = 0) -> _FloatND: ...
+@overload  # tck: (t, c, k)
+def splev(x: onp.ToFloatND, tck: _ToTCK, der: int = 0, ext: _Ext = 0) -> _FloatND | list[_FloatND]: ...
+
+#
+@overload  # tck: BSpline, full_output: falsy
+def splint(a: onp.ToFloat, b: onp.ToFloat, tck: BSpline, full_output: _Falsy = 0) -> _Float | _Float1D: ...
+@overload  # tck: BSpline, full_output: truthy
+def splint(a: onp.ToFloat, b: onp.ToFloat, tck: BSpline, full_output: _Truthy) -> tuple[_Float | _Float1D, _Float1D]: ...
+@overload  # tck: (t, c, k), full_output: falsy
+def splint(a: onp.ToFloat, b: onp.ToFloat, tck: _ToTCK, full_output: _Falsy = 0) -> _Float | list[_Float]: ...
+@overload  # tck: (t, c, k), full_output: truthy
+def splint(a: onp.ToFloat, b: onp.ToFloat, tck: _ToTCK, full_output: _Truthy) -> tuple[_Float | list[_Float], _Float1D]: ...
+
+#
+@overload  # tck: BSpline
+def sproot(tck: BSpline, mest: int = 10) -> _Float1D | _Float2D: ...
+@overload  # tck: (t, c, k)
+def sproot(tck: _ToTCK, mest: int = 10) -> _Float1D | list[_Float1D]: ...
+
+#
+@overload  # x: 1-d
+def spalde(x: onp.ToFloatStrict1D, tck: BSpline | _ToTCK) -> _Float1D: ...
+@overload  # x: 2-d, tck: BSpline
+def spalde(x: onp.ToFloatStrict2D, tck: BSpline) -> _Float2D: ...
+@overload  # x: 2-d, tck: (t, c, k)
+def spalde(x: onp.ToFloatStrict2D, tck: _ToTCK) -> list[_Float1D]: ...
+@overload  # tck: BSpline
+def spalde(x: onp.ToFloat1D | onp.ToFloat2D, tck: BSpline) -> _Float1D | _Float2D: ...
+@overload  # tck: (t, c, k)
+def spalde(x: onp.ToFloat1D | onp.ToFloat2D, tck: _ToTCK) -> _Float1D | list[_Float1D]: ...


### PR DESCRIPTION
This completes the (univariate half) of the `scipy.interpolate` Python `FITPACK` modules (`_fitpack_impl` and `_fitpack_py`). This affects the following public `scipy.interpolate` functions:

- `splprep`
- `splrep`
- `splev`
- `splint`
- `sproot`
- `spalde`

The remaining half (`bisplrep`, `bisplev`, `insert`, `splder`, and `splantider`) will be addressed in a follow-up PR.

towards #101 (-29)