### PR TITLE
✨ `interpolate`: complete `_fitpack_impl` (2/2)

### DIFF
--- a/scipy-stubs/interpolate/_fitpack_impl.pyi
+++ b/scipy-stubs/interpolate/_fitpack_impl.pyi
@@ -4,25 +4,28 @@ from typing_extensions import LiteralString
 
 import numpy as np
 import optype.numpy as onp
-from scipy._typing import Untyped
 
 __all__ = ["bisplev", "bisplrep", "insert", "spalde", "splantider", "splder", "splev", "splint", "splprep", "splrep", "sproot"]
 
 _Falsy: TypeAlias = Literal[False, 0]
 _Truthy: TypeAlias = Literal[True, 1]
 
-_Float: TypeAlias = float | np.float64
 _Float1D: TypeAlias = onp.Array1D[np.float64]
+_Float2D: TypeAlias = onp.Array2D[np.float64]
 _FloatND: TypeAlias = onp.ArrayND[np.float64]
 
 _Task: TypeAlias = Literal[-1, 0, 1]
 _Ext: TypeAlias = Literal[0, 1, 2, 3]
 
+# This coincidentally works for both the univariate and bivariate cases
 _ToTCK: TypeAlias = Sequence[onp.ToFloat1D | onp.ToFloat2D | int]
+
 # `(t, c, k)`
-_OutTCK: TypeAlias = tuple[_Float1D, _Float1D, int]
+_OutTCK1: TypeAlias = tuple[_Float1D, _Float1D, int]
+# `[tx, ty, c, kx, ky]`
+_OutTCK2: TypeAlias = list[_Float1D | _Float2D | int]
 # `([t, c, k], u)`
-_OutTCKU: TypeAlias = tuple[Sequence[_Float1D | list[_Float1D] | int], _Float1D]
+_OutTCKU1: TypeAlias = tuple[list[_Float1D | list[_Float1D] | int], _Float1D]
 
 ###
 
@@ -42,7 +45,7 @@ def splprep(
     nest: int | None = None,
     per: onp.ToBool = 0,
     quiet: onp.ToBool = 1,
-) -> _OutTCKU: ...
+) -> _OutTCKU1: ...
 @overload  # full_output: truthy (positional)
 def splprep(
     x: onp.ToFloat2D,
@@ -58,7 +61,7 @@ def splprep(
     nest: int | None = None,
     per: onp.ToBool = 0,
     quiet: onp.ToBool = 1,
-) -> tuple[_OutTCKU, _Float, int, LiteralString]: ...
+) -> tuple[_OutTCKU1, float, int, LiteralString]: ...
 @overload  # full_output: truthy (keyword)
 def splprep(
     x: onp.ToFloat2D,
@@ -75,7 +78,7 @@ def splprep(
     nest: int | None = None,
     per: onp.ToBool = 0,
     quiet: onp.ToBool = 1,
-) -> tuple[_OutTCKU, _Float, int, LiteralString]: ...
+) -> tuple[_OutTCKU1, float, int, LiteralString]: ...
 
 #
 @overload  # full_output: falsy = ...
@@ -92,7 +95,7 @@ def splrep(
     full_output: _Falsy = 0,
     per: onp.ToBool = 0,
     quiet: onp.ToBool = 1,
-) -> _OutTCK: ...
+) -> _OutTCK1: ...
 @overload  # full_output: truthy (positional)
 def splrep(
     x: onp.ToFloat1D,
@@ -107,7 +110,7 @@ def splrep(
     full_output: _Truthy,
     per: onp.ToBool = 0,
     quiet: onp.ToBool = 1,
-) -> tuple[_OutTCK, _Float, int, LiteralString]: ...
+) -> tuple[_OutTCK1, float, int, LiteralString]: ...
 @overload  # full_output: truthy (keyword)
 def splrep(
     x: onp.ToFloat1D,
@@ -123,63 +126,102 @@ def splrep(
     full_output: _Truthy,
     per: onp.ToBool = 0,
     quiet: onp.ToBool = 1,
-) -> tuple[_OutTCK, _Float, int, LiteralString]: ...
+) -> tuple[_OutTCK1, float, int, LiteralString]: ...
 
 #
 def splev(x: onp.ToFloatND, tck: _ToTCK, der: int = 0, ext: _Ext = 0) -> _FloatND: ...
 
 #
 @overload  # full_output: falsy
-def splint(a: onp.ToFloat, b: onp.ToFloat, tck: _ToTCK, full_output: _Falsy = 0) -> _Float | list[_Float]: ...
+def splint(a: onp.ToFloat, b: onp.ToFloat, tck: _ToTCK, full_output: _Falsy = 0) -> float | list[float]: ...
 @overload  # full_output: truthy
-def splint(a: onp.ToFloat, b: onp.ToFloat, tck: _ToTCK, full_output: _Truthy) -> tuple[_Float | list[_Float], _Float1D]: ...
+def splint(a: onp.ToFloat, b: onp.ToFloat, tck: _ToTCK, full_output: _Truthy) -> tuple[float | list[float], _Float1D]: ...
 
 #
 def sproot(tck: _ToTCK, mest: int = 10) -> _Float1D | list[_Float1D]: ...
 
 #
-@overload
+@overload  # x: 1-d
 def spalde(x: onp.ToFloatStrict1D, tck: _ToTCK) -> _Float1D: ...
-@overload
+@overload  # x: 2-d
 def spalde(x: onp.ToFloatStrict2D, tck: _ToTCK) -> list[_Float1D]: ...
-@overload
+@overload  # x: {1,2}-d
 def spalde(x: onp.ToFloat1D | onp.ToFloat2D, tck: _ToTCK) -> _Float1D | list[_Float1D]: ...
 
 #
-# TODO(jorenham): full_output=True
+@overload  # full_output: falsy = ...
 def bisplrep(
-    x: Untyped,
-    y: Untyped,
-    z: Untyped,
-    w: Untyped | None = None,
-    xb: Untyped | None = None,
-    xe: Untyped | None = None,
-    yb: Untyped | None = None,
-    ye: Untyped | None = None,
+    x: onp.ToFloat1D,
+    y: onp.ToFloat1D,
+    z: onp.ToFloat1D,
+    w: onp.ToFloat1D | None = None,
+    xb: onp.ToFloat | None = None,
+    xe: onp.ToFloat | None = None,
+    yb: onp.ToFloat | None = None,
+    ye: onp.ToFloat | None = None,
     kx: int = 3,
     ky: int = 3,
     task: _Task = 0,
-    s: Untyped | None = None,
-    eps: float = 1e-16,
-    tx: Untyped | None = None,
-    ty: Untyped | None = None,
+    s: onp.ToFloat | None = None,
+    eps: onp.ToFloat = 1e-16,
+    tx: onp.ToFloat1D | None = None,
+    ty: onp.ToFloat1D | None = None,
     full_output: _Falsy = 0,
-    nxest: Untyped | None = None,
-    nyest: Untyped | None = None,
-    quiet: int = 1,
-) -> Untyped: ...
+    nxest: onp.ToFloat | None = None,
+    nyest: onp.ToFloat | None = None,
+    quiet: onp.ToBool = 1,
+) -> _OutTCK2: ...
+@overload  # full_output: truthy (positional)
+def bisplrep(
+    x: onp.ToFloat1D,
+    y: onp.ToFloat1D,
+    z: onp.ToFloat1D,
+    w: onp.ToFloat1D | None,
+    xb: onp.ToFloat | None,
+    xe: onp.ToFloat | None,
+    yb: onp.ToFloat | None,
+    ye: onp.ToFloat | None,
+    kx: int,
+    ky: int,
+    task: _Task,
+    s: onp.ToFloat | None,
+    eps: onp.ToFloat,
+    tx: onp.ToFloat1D | None,
+    ty: onp.ToFloat1D | None,
+    full_output: _Truthy,
+    nxest: onp.ToFloat | None = None,
+    nyest: onp.ToFloat | None = None,
+    quiet: onp.ToBool = 1,
+) -> tuple[_OutTCK2, float, int, LiteralString]: ...
+@overload  # full_output: truthy (keyword)
+def bisplrep(
+    x: onp.ToFloat1D,
+    y: onp.ToFloat1D,
+    z: onp.ToFloat1D,
+    w: onp.ToFloat1D | None = None,
+    xb: onp.ToFloat | None = None,
+    xe: onp.ToFloat | None = None,
+    yb: onp.ToFloat | None = None,
+    ye: onp.ToFloat | None = None,
+    kx: int = 3,
+    ky: int = 3,
+    task: _Task = 0,
+    s: onp.ToFloat | None = None,
+    eps: onp.ToFloat = 1e-16,
+    tx: onp.ToFloat1D | None = None,
+    ty: onp.ToFloat1D | None = None,
+    *,
+    full_output: _Truthy,
+    nxest: onp.ToFloat | None = None,
+    nyest: onp.ToFloat | None = None,
+    quiet: onp.ToBool = 1,
+) -> tuple[_OutTCK2, float, int, LiteralString]: ...
 
-#
-def bisplev(x: Untyped, y: Untyped, tck: Untyped, dx: int = 0, dy: int = 0) -> Untyped: ...
+# requires `len(tck) == 5`
+def bisplev(x: onp.ToFloat1D, y: onp.ToFloat1D, tck: _ToTCK, dx: int = 0, dy: int = 0) -> _Float2D: ...
+def dblint(xa: onp.ToFloat, xb: onp.ToFloat, ya: onp.ToFloat, yb: onp.ToFloat, tck: _ToTCK) -> float: ...
 
-#
-def dblint(xa: Untyped, xb: Untyped, ya: Untyped, yb: Untyped, tck: Untyped) -> Untyped: ...
-
-#
-def insert(x: Untyped, tck: Untyped, m: int = 1, per: int = 0) -> Untyped: ...
-
-#
-def splder(tck: Untyped, n: int = 1) -> Untyped: ...
-
-#
-def splantider(tck: Untyped, n: int = 1) -> Untyped: ...
+# requires `len(tck) == 3`
+def insert(x: onp.ToFloat, tck: _ToTCK, m: int = 1, per: onp.ToBool = 0) -> _OutTCK1: ...
+def splder(tck: _ToTCK, n: int = 1) -> _OutTCK1: ...
+def splantider(tck: _ToTCK, n: int = 1) -> _OutTCK1: ...

--- a/scipy-stubs/interpolate/_fitpack_py.pyi
+++ b/scipy-stubs/interpolate/_fitpack_py.pyi
@@ -4,7 +4,7 @@ from typing import Literal, TypeAlias, overload
 import numpy as np
 import optype.numpy as onp
 from ._bsplines import BSpline
-from ._fitpack_impl import bisplev, bisplrep, insert, splantider, splder, splprep, splrep
+from ._fitpack_impl import bisplev, bisplrep, splprep, splrep
 
 __all__ = ["bisplev", "bisplrep", "insert", "spalde", "splantider", "splder", "splev", "splint", "splprep", "splrep", "sproot"]
 
@@ -18,6 +18,7 @@ _FloatND: TypeAlias = onp.ArrayND[np.float64]
 
 _Ext: TypeAlias = Literal[0, 1, 2, 3]
 _ToTCK: TypeAlias = Sequence[onp.ToFloat1D | onp.ToFloat2D | int]
+_TCK: TypeAlias = tuple[_Float1D, _Float1D, int]
 
 ###
 
@@ -56,3 +57,19 @@ def spalde(x: onp.ToFloatStrict2D, tck: _ToTCK) -> list[_Float1D]: ...
 def spalde(x: onp.ToFloat1D | onp.ToFloat2D, tck: BSpline) -> _Float1D | _Float2D: ...
 @overload  # tck: (t, c, k)
 def spalde(x: onp.ToFloat1D | onp.ToFloat2D, tck: _ToTCK) -> _Float1D | list[_Float1D]: ...
+@overload  # tck: BSpline
+def insert(x: onp.ToFloat, tck: BSpline, m: int = 1, per: onp.ToBool = 0) -> BSpline[np.float64]: ...
+@overload  # tck: (t, c, k)
+def insert(x: onp.ToFloat, tck: _ToTCK, m: int = 1, per: onp.ToBool = 0) -> _TCK: ...
+
+#
+@overload  # tck: BSpline
+def splder(tck: BSpline, n: int = 1) -> BSpline[np.float64]: ...
+@overload  # tck: (t, c, k)
+def splder(tck: _ToTCK, n: int = 1) -> _TCK: ...
+
+#
+@overload  # tck: BSpline
+def splantider(tck: BSpline, n: int = 1) -> BSpline[np.float64]: ...
+@overload  # tck: (t, c, k)
+def splantider(tck: _ToTCK, n: int = 1) -> _TCK: ...


### PR DESCRIPTION
This affects the following public `scipy.interpolate` functions:

- `bisplrep`
- `bisplev`
- `insert`
- `splder`
- `splantider`


follows #275
towards #101 (-32)
