### PR TITLE
✨ `interpolate`: complete `_fitpack2`

### DIFF
--- a/scipy-stubs/interpolate/_fitpack2.pyi
+++ b/scipy-stubs/interpolate/_fitpack2.pyi
@@ -1,7 +1,9 @@
-from typing_extensions import override
+from collections.abc import Sequence
+from typing import Literal, TypeAlias
+from typing_extensions import Never, override
 
-import numpy.typing as npt
-from scipy._typing import Untyped
+import numpy as np
+import optype.numpy as onp
 
 __all__ = [
     "BivariateSpline",
@@ -16,219 +18,220 @@ __all__ = [
     "UnivariateSpline",
 ]
 
+_Float1D: TypeAlias = onp.Array1D[np.float64]
+_FloatND: TypeAlias = onp.Array2D[np.float64]
+
+_Degree: TypeAlias = Literal[1, 2, 3, 4, 5]
+
+_ExtInt: TypeAlias = Literal[0, 1, 2, 3]
+_ExtStr: TypeAlias = Literal["extrapolate", "zeroes", "raise", "const"]
+_Ext: TypeAlias = _ExtInt | _ExtStr
+
+_BBox: TypeAlias = onp.Array[tuple[Literal[2]], np.float64]
+_ToBBox: TypeAlias = Sequence[onp.ToFloat | None]
+
+###
+
 class UnivariateSpline:
+    @staticmethod
+    def validate_input(
+        x: onp.ToFloat1D,
+        y: onp.ToFloat1D,
+        w: onp.ToFloat1D,
+        bbox: _ToBBox,
+        k: _Degree,
+        s: onp.ToFloat | None,
+        ext: _Ext,
+        check_finite: onp.ToBool,
+    ) -> tuple[_Float1D, _Float1D, _Float1D, _BBox, _ExtInt]: ...
+
     # at runtime the `__init__` might change the `__class__` attribute...
     def __init__(
         self,
         /,
-        x: npt.ArrayLike,
-        y: npt.ArrayLike,
-        w: npt.ArrayLike | None = None,
-        bbox: npt.ArrayLike = ...,
-        k: int = 3,
-        s: float | None = None,
-        ext: int | str = 0,
-        check_finite: bool = False,
+        x: onp.ToFloat1D,
+        y: onp.ToFloat1D,
+        w: onp.ToFloat1D | None = None,
+        bbox: _ToBBox = [None, None],  # size 2
+        k: _Degree = 3,
+        s: onp.ToFloat | None = None,
+        ext: _Ext = 0,
+        check_finite: onp.ToBool = False,
     ) -> None: ...
-    def __call__(self, /, x: Untyped, nu: int = 0, ext: Untyped | None = None) -> Untyped: ...
-    def set_smoothing_factor(self, /, s: Untyped) -> None: ...
-    def get_knots(self, /) -> Untyped: ...
-    def get_coeffs(self, /) -> Untyped: ...
-    def get_residual(self, /) -> Untyped: ...
-    def integral(self, /, a: Untyped, b: Untyped) -> Untyped: ...
-    def derivatives(self, /, x: npt.ArrayLike) -> Untyped: ...
-    def roots(self, /) -> Untyped: ...
-    def derivative(self, /, n: int = 1) -> Untyped: ...
-    def antiderivative(self, /, n: int = 1) -> Untyped: ...
-    @staticmethod
-    def validate_input(
-        x: npt.ArrayLike,
-        y: npt.ArrayLike,
-        w: npt.ArrayLike,
-        bbox: npt.ArrayLike,
-        k: int,
-        s: float | None,
-        ext: int,
-        check_finite: bool,
-    ) -> Untyped: ...
+    def __call__(self, /, x: onp.ToFloat1D, nu: int = 0, ext: _Ext | None = None) -> _Float1D: ...
+
+    #
+    def get_knots(self, /) -> _Float1D: ...
+    def get_coeffs(self, /) -> _Float1D: ...
+    def get_residual(self, /) -> _Float1D: ...
+    def set_smoothing_factor(self, /, s: onp.ToFloat) -> None: ...
+
+    #
+    def roots(self, /) -> _Float1D: ...  # requires `self.k == 3`
+    def derivatives(self, /, x: onp.ToFloat) -> _Float1D: ...
+    def derivative(self, /, n: int = 1) -> UnivariateSpline: ...
+    def antiderivative(self, /, n: int = 1) -> UnivariateSpline: ...
+    def integral(self, /, a: onp.ToFloat, b: onp.ToFloat) -> float: ...
 
 class InterpolatedUnivariateSpline(UnivariateSpline):
     def __init__(
         self,
         /,
-        x: npt.ArrayLike,
-        y: npt.ArrayLike,
-        w: npt.ArrayLike | None = None,
-        bbox: npt.ArrayLike = ...,
-        k: int = 3,
-        ext: int | str = 0,
-        check_finite: bool = False,
+        x: onp.ToFloat1D,
+        y: onp.ToFloat1D,
+        w: onp.ToFloat1D | None = None,
+        bbox: _ToBBox = [None, None],  # size 2
+        k: _Degree = 3,
+        ext: _Ext = 0,
+        check_finite: onp.ToBool = False,
     ) -> None: ...
 
 class LSQUnivariateSpline(UnivariateSpline):
     def __init__(
         self,
         /,
-        x: npt.ArrayLike,
-        y: npt.ArrayLike,
-        t: npt.ArrayLike,
-        w: npt.ArrayLike | None = None,
-        bbox: npt.ArrayLike = ...,
-        k: int = 3,
-        ext: int = 0,
-        check_finite: bool = False,
+        x: onp.ToFloat1D,
+        y: onp.ToFloat1D,
+        t: onp.ToFloat1D,
+        w: onp.ToFloat1D | None = None,
+        bbox: _ToBBox = [None, None],  # size 2
+        k: _Degree = 3,
+        ext: _Ext = 0,
+        check_finite: onp.ToBool = False,
     ) -> None: ...
 
 class _BivariateSplineBase:  # undocumented
-    def __call__(self, /, x: npt.ArrayLike, y: npt.ArrayLike, dx: int = 0, dy: int = 0, grid: bool = True) -> Untyped: ...
-    def get_residual(self, /) -> Untyped: ...
-    def get_knots(self, /) -> Untyped: ...
-    def get_coeffs(self, /) -> Untyped: ...
-    def partial_derivative(self, /, dx: int, dy: int) -> Untyped: ...
+    def __call__(self, /, x: onp.ToFloatND, y: onp.ToFloatND, dx: int = 0, dy: int = 0, grid: onp.ToBool = True) -> _Float1D: ...
+    def get_residual(self, /) -> _Float1D: ...
+    def get_knots(self, /) -> tuple[_Float1D, _Float1D]: ...
+    def get_coeffs(self, /) -> _Float1D: ...
+    def partial_derivative(self, /, dx: int, dy: int) -> _DerivedBivariateSpline: ...
 
 class BivariateSpline(_BivariateSplineBase):
-    def ev(self, /, xi: npt.ArrayLike, yi: npt.ArrayLike, dx: int = 0, dy: int = 0) -> Untyped: ...
-    def integral(self, /, xa: float, xb: float, ya: float, yb: float) -> Untyped: ...
+    def ev(self, /, xi: onp.ToFloatND, yi: onp.ToFloatND, dx: int = 0, dy: int = 0) -> _FloatND: ...
+    def integral(self, /, xa: onp.ToFloat, xb: onp.ToFloat, ya: onp.ToFloat, yb: onp.ToFloat) -> float: ...
 
 class _DerivedBivariateSpline(_BivariateSplineBase):  # undocumented
     @property
-    def fp(self, /) -> Untyped: ...
+    def fp(self, /) -> Never: ...
 
 class SmoothBivariateSpline(BivariateSpline):
-    fp: Untyped
-    tck: Untyped
-    degrees: Untyped
+    fp: float
+    tck: tuple[_Float1D, _Float1D, int]
+    degrees: tuple[int, int]
 
     def __init__(
         self,
         /,
-        x: npt.ArrayLike,
-        y: npt.ArrayLike,
-        z: npt.ArrayLike,
-        w: npt.ArrayLike | None = None,
-        bbox: npt.ArrayLike = ...,  # [None]
+        x: onp.ToFloat1D,
+        y: onp.ToFloat1D,
+        z: onp.ToFloat1D,
+        w: onp.ToFloat1D | None = None,
+        bbox: _ToBBox = [None, None, None, None],
         kx: int = 3,
         ky: int = 3,
-        s: float | None = None,
-        eps: float = 1e-16,
+        s: onp.ToFloat | None = None,
+        eps: onp.ToFloat = 1e-16,
     ) -> None: ...
 
 class LSQBivariateSpline(BivariateSpline):
-    fp: Untyped
-    tck: Untyped
-    degrees: Untyped
+    fp: float
+    tck: tuple[_Float1D, _Float1D, int]
+    degrees: tuple[int, int]
 
     def __init__(
         self,
         /,
-        x: npt.ArrayLike,
-        y: npt.ArrayLike,
-        z: npt.ArrayLike,
-        tx: Untyped,
-        ty: Untyped,
-        w: Untyped | None = None,
-        bbox: Untyped = ...,
+        x: onp.ToFloat1D,
+        y: onp.ToFloat1D,
+        z: onp.ToFloat1D,
+        tx: onp.ToFloat1D,
+        ty: onp.ToFloat1D,
+        w: onp.ToFloat1D | None = None,
+        bbox: _ToBBox = [None, None, None, None],
         kx: int = 3,
         ky: int = 3,
-        eps: Untyped | None = None,
+        eps: onp.ToFloat | None = None,
     ) -> None: ...
 
 class RectBivariateSpline(BivariateSpline):
-    fp: Untyped
-    tck: Untyped
-    degrees: Untyped
+    fp: float
+    tck: tuple[_Float1D, _Float1D, int]
+    degrees: tuple[int, int]
 
     def __init__(
         self,
         /,
-        x: npt.ArrayLike,
-        y: npt.ArrayLike,
-        z: npt.ArrayLike,
-        bbox: Untyped = ...,
+        x: onp.ToFloat1D,
+        y: onp.ToFloat1D,
+        z: onp.ToFloat2D,
+        bbox: _ToBBox = [None, None, None, None],
         kx: int = 3,
         ky: int = 3,
-        s: int = 0,
+        s: onp.ToFloat = 0,
     ) -> None: ...
 
 class SphereBivariateSpline(_BivariateSplineBase):
     @override
-    def __call__(  # type: ignore[override]
+    def __call__(  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         /,
-        theta: npt.ArrayLike,
-        phi: npt.ArrayLike,
+        theta: onp.ToFloat1D,
+        phi: onp.ToFloat1D,
         dtheta: int = 0,
         dphi: int = 0,
-        grid: bool = True,
-    ) -> Untyped: ...
-    def ev(self, /, theta: Untyped, phi: Untyped, dtheta: int = 0, dphi: int = 0) -> Untyped: ...
+        grid: onp.ToBool = True,
+    ) -> _FloatND: ...
+    def ev(self, /, theta: onp.ToFloatND, phi: onp.ToFloatND, dtheta: int = 0, dphi: int = 0) -> _FloatND: ...
 
 class SmoothSphereBivariateSpline(SphereBivariateSpline):
-    fp: Untyped
-    tck: Untyped
-    degrees: Untyped
+    fp: float
+    tck: tuple[_Float1D, _Float1D, int]
+    degrees: tuple[int, int]
 
     def __init__(
         self,
         /,
-        theta: npt.ArrayLike,
-        phi: npt.ArrayLike,
-        r: npt.ArrayLike,
-        w: Untyped | None = None,
-        s: float = 0.0,
-        eps: float = 1e-16,
+        theta: onp.ToFloat1D,
+        phi: onp.ToFloat1D,
+        r: onp.ToFloat1D,
+        w: onp.ToFloat1D | None = None,
+        s: onp.ToFloat = 0.0,
+        eps: onp.ToFloat = 1e-16,
     ) -> None: ...
 
 class LSQSphereBivariateSpline(SphereBivariateSpline):
-    fp: Untyped
-    tck: Untyped
-    degrees: Untyped
+    fp: float
+    tck: tuple[_Float1D, _Float1D, int]
+    degrees: tuple[int, int]
+
     def __init__(
         self,
         /,
-        theta: npt.ArrayLike,
-        phi: npt.ArrayLike,
-        r: npt.ArrayLike,
-        tt: Untyped,
-        tp: Untyped,
-        w: Untyped | None = None,
-        eps: float = 1e-16,
+        theta: onp.ToFloat1D,
+        phi: onp.ToFloat1D,
+        r: onp.ToFloat1D,
+        tt: onp.ToFloat1D,
+        tp: onp.ToFloat1D,
+        w: onp.ToFloat1D | None = None,
+        eps: onp.ToFloat = 1e-16,
     ) -> None: ...
-    @override
-    def __call__(  # type: ignore[override]
-        self,
-        /,
-        theta: npt.ArrayLike,
-        phi: npt.ArrayLike,
-        dtheta: int = 0,
-        dphi: int = 0,
-        grid: bool = True,
-    ) -> Untyped: ...
 
 class RectSphereBivariateSpline(SphereBivariateSpline):
-    fp: Untyped
-    tck: Untyped
-    degrees: Untyped
-    v0: Untyped
+    fp: float
+    tck: tuple[_Float1D, _Float1D, int]
+    degrees: tuple[int, int]
+    v0: np.float64
+
     def __init__(
         self,
         /,
-        u: Untyped,
-        v: Untyped,
-        r: Untyped,
-        s: float = 0.0,
-        pole_continuity: bool = False,
-        pole_values: Untyped | None = None,
-        pole_exact: bool = False,
-        pole_flat: bool = False,
+        u: onp.ToFloat1D,
+        v: onp.ToFloat1D,
+        r: onp.ToFloat2D,
+        s: onp.ToFloat = 0.0,
+        pole_continuity: onp.ToBool | tuple[onp.ToBool, onp.ToBool] = False,
+        pole_values: onp.ToFloat | tuple[onp.ToFloat, onp.ToFloat] | None = None,
+        pole_exact: onp.ToBool | tuple[onp.ToBool, onp.ToBool] = False,
+        pole_flat: onp.ToBool | tuple[onp.ToBool, onp.ToBool] = False,
     ) -> None: ...
-    @override
-    def __call__(  # type: ignore[override]
-        self,
-        /,
-        theta: npt.ArrayLike,
-        phi: npt.ArrayLike,
-        dtheta: int = 0,
-        dphi: int = 0,
-        grid: bool = True,
-    ) -> Untyped: ...


### PR DESCRIPTION
This affects the following `scipy.interpolate` members:

- `UnivariateSpline`
- `InterpolatedUnivariateSpline`
- `LSQUnivariateSpline`
- `BivariateSpline`
- `SphereBivariateSpline`
- `SmoothBivariateSpline`
- `SmoothSphereBivariateSpline`
- `LSQBivariateSpline`
- `LSQSphereBivariateSpline`
- `RectBivariateSpline`
- `RectSphereBivariateSpline`

towards #101 (-63)