### PR TITLE
✨ `interpolate`: complete `_rgi`

### DIFF
--- a/scipy-stubs/interpolate/_bsplines.pyi
+++ b/scipy-stubs/interpolate/_bsplines.pyi
@@ -4,7 +4,6 @@ from typing_extensions import Self
 import numpy as np
 import optype as op
 import optype.numpy as onp
-from scipy._typing import Untyped
 from scipy.interpolate import CubicSpline
 from scipy.sparse import csr_array
 
@@ -25,7 +24,7 @@ class BSpline(Generic[_SCT_co]):
     axis: int
 
     @property
-    def tck(self, /) -> Untyped: ...
+    def tck(self, /) -> tuple[onp.Array1D[np.float64], onp.Array[onp.AtLeast1D, _SCT_co], int]: ...
 
     #
     def __init__(
@@ -43,7 +42,7 @@ class BSpline(Generic[_SCT_co]):
     def derivative(self, /, nu: int = 1) -> Self: ...
     def antiderivative(self, /, nu: int = 1) -> Self: ...
     def integrate(self, /, a: onp.ToFloat, b: onp.ToFloat, extrapolate: _Extrapolate | None = None) -> onp.ArrayND[_SCT_co]: ...
-    def insert_knot(self, /, x: onp.ToFloat, m: op.CanIndex = 1) -> Untyped: ...
+    def insert_knot(self, /, x: onp.ToFloat, m: op.CanIndex = 1) -> Self: ...
 
     #
     @classmethod

--- a/scipy-stubs/interpolate/_rgi.pyi
+++ b/scipy-stubs/interpolate/_rgi.pyi
@@ -1,31 +1,78 @@
-from scipy._typing import Untyped
+from collections.abc import Callable
+from typing import Concatenate, Generic, Literal, TypeAlias, overload
+from typing_extensions import TypeVar
+
+import numpy as np
+import optype.numpy as onp
 
 __all__ = ["RegularGridInterpolator", "interpn"]
 
-class RegularGridInterpolator:
-    method: Untyped
-    bounds_error: Untyped
-    values: Untyped
-    fill_value: Untyped
+_MethodReal: TypeAlias = Literal["linear", "nearest", "slinear", "cubic", "quintic"]
+_Method: TypeAlias = Literal[_MethodReal, "pchip"]
+
+_SCT_co = TypeVar("_SCT_co", bound=np.float64 | np.complex128, default=np.float64 | np.complex128, covariant=True)
+
+###
+
+class RegularGridInterpolator(Generic[_SCT_co]):
+    grid: tuple[onp.ArrayND[_SCT_co], ...]
+    values: onp.ArrayND[_SCT_co]
+    method: _Method
+    fill_value: float | None
+    bounds_error: bool
+
+    @overload
+    def __init__(
+        self: RegularGridInterpolator[np.float64],
+        /,
+        points: tuple[onp.ToFloat1D, ...],
+        values: onp.ToFloatND,
+        method: _Method = "linear",
+        bounds_error: onp.ToBool = True,
+        fill_value: onp.ToFloat | None = ...,  # np.nan
+        *,
+        solver: Callable[Concatenate[onp.Array2D[np.float64], ...], tuple[onp.Array1D[np.float64]]] | None = None,
+        solver_args: tuple[object, ...] | None = None,
+    ) -> None: ...
+    @overload
     def __init__(
         self,
         /,
-        points: Untyped,
-        values: Untyped,
-        method: str = "linear",
-        bounds_error: bool = True,
-        fill_value: Untyped = ...,
+        points: tuple[onp.ToFloat1D, ...],
+        values: onp.ToComplexND,
+        method: _MethodReal = "linear",
+        bounds_error: onp.ToBool = True,
+        fill_value: onp.ToComplex | None = ...,  # np.nan
         *,
-        solver: Untyped | None = None,
-        solver_args: Untyped | None = None,
+        solver: Callable[Concatenate[onp.Array2D[np.float64], ...], tuple[onp.Array1D[np.float64]]] | None = None,
+        solver_args: tuple[object, ...] | None = None,
     ) -> None: ...
-    def __call__(self, /, xi: Untyped, method: Untyped | None = None, *, nu: Untyped | None = None) -> Untyped: ...
 
+    #
+    def __call__(
+        self,
+        /,
+        xi: onp.ToFloatND,
+        method: _Method | None = None,
+        *,
+        nu: onp.ToJustInt1D | None = None,
+    ) -> onp.ArrayND[_SCT_co]: ...
+
+@overload
 def interpn(
-    points: Untyped,
-    values: Untyped,
-    xi: Untyped,
-    method: str = "linear",
-    bounds_error: bool = True,
-    fill_value: Untyped = ...,
-) -> Untyped: ...
+    points: tuple[onp.ToFloat1D, ...],
+    values: onp.ToFloatND,
+    xi: onp.ToFloatND,
+    method: _Method = "linear",
+    bounds_error: onp.ToBool = True,
+    fill_value: onp.ToFloat = ...,  # np.nan
+) -> onp.ArrayND[np.float64]: ...
+@overload
+def interpn(
+    points: tuple[onp.ToFloat1D, ...],
+    values: onp.ToComplex1D,
+    xi: onp.ToFloatND,
+    method: _Method = "linear",
+    bounds_error: onp.ToBool = True,
+    fill_value: onp.ToComplex = ...,  # np.nan
+) -> onp.ArrayND[np.float64 | np.complex128]: ...


### PR DESCRIPTION
This affects the following `scipy.interpolate` members:

- `RegularGridInterpolator`
- `interpn`

towards #101 (-22)