### PR TITLE
💚 fix `typetest-oldest-supported-numpy` CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,13 +70,31 @@ jobs:
       - name: setup uv
         uses: astral-sh/setup-uv@v4
 
-      - name: install
-        run: |
-          uv sync --frozen --python=$(uv run --frozen scripts/version_bounds.py python)
-          uv pip install --upgrade numpy==$(uv run --frozen scripts/version_bounds.py numpy)
+      - name: basedpyright
+        run: >
+          uv run
+          --python $(uv run scripts/version_bounds.py python)
+          --with numpy==$(uv run scripts/version_bounds.py numpy)
+          basedpyright
 
-      - name: typetest
-        run: uv run poe typetest
+      - name: basedmypy
+        run: >
+          uv run
+          --no-editable
+          --isolated
+          --python $(uv run scripts/version_bounds.py python)
+          --with numpy==$(uv run scripts/version_bounds.py numpy)
+          mypy --config-file=pyproject.toml .
 
       - name: stubtest
-        run: uv run poe stubtest
+        run: >
+          uv run
+          --no-editable
+          --isolated
+          --python $(uv run scripts/version_bounds.py python)
+          --with numpy==$(uv run scripts/version_bounds.py numpy)
+          stubtest
+          --mypy-config-file pyproject.toml
+          --allowlist .mypyignore
+          --ignore-unused-allowlist
+          scipy

--- a/scripts/version_bounds.py
+++ b/scripts/version_bounds.py
@@ -14,7 +14,8 @@ def scipy_minimum_python() -> str:
 
 def scipy_minimum_numpy() -> str:
     """Fetch the minimum numpy version required by the current scipy package."""
-    np_minimum_dep = next(req for req in importlib.metadata.requires("scipy") if req.startswith("numpy") and " extra " not in req)
+    reqs = importlib.metadata.requires("scipy") or []
+    np_minimum_dep = next(req for req in reqs if req.startswith("numpy") and " extra " not in req)
     np_minimum_dep = next(ver for ver in np_minimum_dep.split(",") if ">" in ver)
     return np_minimum_dep.replace("numpy", "").replace(">=", "").replace(">", "")
 


### PR DESCRIPTION
apparently mypy was still using the latest numpy because it doesn't understand editable projects and has to be run in an isolated uv env which doesn't include the `uv pip install`'ed numpy version or the correct python version