### PR TITLE
✨ `sparse.linalg`: complete the `LinearOperator`s in `_interface`

### DIFF
--- a/scipy-stubs/optimize/_lbfgsb_py.pyi
+++ b/scipy-stubs/optimize/_lbfgsb_py.pyi
@@ -17,16 +17,15 @@ class _InfoDict(TypedDict):
     nit: int
     warnflag: Literal[0, 1, 2]
 
-#
+###
 
-class LbfgsInvHessProduct(LinearOperator):
+class LbfgsInvHessProduct(LinearOperator[np.float64]):
     sk: Final[onp.Array2D[np.float64]]
     yk: Final[onp.Array2D[np.float64]]
     n_corrs: Final[int]
     rho: Final[float | np.float64]
 
     def __init__(self, /, sk: onp.ToFloat2D, yk: onp.ToFloat2D) -> None: ...
-    def _matvec(self, /, x: onp.ToFloat1D | onp.ToFloat2D) -> onp.Array1D[np.float64]: ...
     def todense(self, /) -> onp.Array2D[np.float64]: ...
 
 def fmin_l_bfgs_b(

--- a/scipy-stubs/sparse/linalg/_interface.pyi
+++ b/scipy-stubs/sparse/linalg/_interface.pyi
@@ -1,106 +1,336 @@
+# mypy: disable-error-code="override"
 # pyright: reportInconsistentConstructor=false
+# pyright: reportIncompatibleMethodOverride=false
+# pyright: reportIncompatibleVariableOverride=false
+# pyright: reportUnannotatedClassAttribute=false
 
-from collections.abc import Sequence
-from typing import ClassVar, Literal, TypeAlias
-from typing_extensions import Self, override
+from collections.abc import Callable, Iterable
+from typing import Any, ClassVar, Final, Generic, Literal, Protocol, TypeAlias, final, overload, type_check_only
+from typing_extensions import Self, TypeVar, override
 
 import numpy as np
-import numpy.typing as npt
+import optype as op
 import optype.numpy as onp
-from scipy._typing import Untyped, UntypedArray, UntypedTuple
+import optype.typing as opt
+from scipy.sparse._base import _spbase
 
 __all__ = ["LinearOperator", "aslinearoperator"]
 
-_ToLinearOperator: TypeAlias = LinearOperator | onp.ToComplex1D | onp.ToComplex2D
+_NumberT = TypeVar("_NumberT", bound=np.number[Any])
+_Matrix: TypeAlias = np.matrix[Any, np.dtype[_NumberT]]
+
+_ToShape: TypeAlias = Iterable[op.CanIndex]
+_ToDType: TypeAlias = type[_SCT] | onp.HasDType[np.dtype[_SCT]] | np.dtype[_SCT]
+
+_JustComplex: TypeAlias = opt.Just[complex]
+
+_FunMatVec: TypeAlias = Callable[[onp.Array1D[np.number[Any]] | onp.Array2D[np.number[Any]]], onp.ToComplex1D | onp.ToComplex2D]
+_FunMatMat: TypeAlias = Callable[[onp.Array2D[np.number[Any]]], onp.ToComplex2D]
+
+_SCT = TypeVar("_SCT", bound=np.inexact[Any])
+_SCT_co = TypeVar("_SCT_co", bound=np.inexact[Any], default=np.inexact[Any], covariant=True)
+_SCT1_co = TypeVar("_SCT1_co", bound=np.inexact[Any], default=np.inexact[Any], covariant=True)
+_SCT2_co = TypeVar("_SCT2_co", bound=np.inexact[Any], default=_SCT1_co, covariant=True)
+_FunMatVecT_co = TypeVar("_FunMatVecT_co", bound=_FunMatVec, default=_FunMatVec, covariant=True)
 
 ###
 
-# TODO: make these all generic
-class LinearOperator:
+class LinearOperator(Generic[_SCT_co]):
     __array_ufunc__: ClassVar[None]
 
-    shape: tuple[int] | tuple[int, int]
-    ndim: Literal[1, 2]
-    dtype: np.dtype[np.generic]
+    ndim: ClassVar[Literal[2]] = 2
+    shape: Final[tuple[int, int]]
+    dtype: np.dtype[_SCT_co]
 
-    def __new__(cls, *args: Untyped, **kwargs: Untyped) -> Self: ...
-    def __init__(self, /, dtype: npt.DTypeLike, shape: onp.ToInt | Sequence[onp.ToInt]) -> None: ...
-    def matvec(self, /, x: onp.ToComplex1D | onp.ToComplex2D) -> UntypedArray: ...
-    def rmatvec(self, /, x: onp.ToComplex1D | onp.ToComplex2D) -> UntypedArray: ...
-    def matmat(self, /, X: onp.ToComplex2D) -> UntypedArray: ...
-    def rmatmat(self, /, X: onp.ToComplex2D) -> UntypedArray: ...
-    def __call__(self, /, x: _ToLinearOperator) -> _ProductLinearOperator | _ScaledLinearOperator | UntypedArray: ...
-    def __mul__(self, x: _ToLinearOperator, /) -> _ProductLinearOperator | _ScaledLinearOperator | UntypedArray: ...
-    def __truediv__(self, other: onp.ToScalar, /) -> _ScaledLinearOperator: ...
-    def dot(self, /, x: _ToLinearOperator) -> _ProductLinearOperator | _ScaledLinearOperator | UntypedArray: ...
-    def __matmul__(self, other: _ToLinearOperator, /) -> _ScaledLinearOperator | UntypedArray: ...
-    def __rmatmul__(self, other: _ToLinearOperator, /) -> _ScaledLinearOperator | UntypedArray: ...
-    def __rmul__(self, x: _ToLinearOperator, /) -> Untyped: ...
-    def __pow__(self, p: onp.ToScalar, /) -> _PowerLinearOperator: ...
-    def __add__(self, x: LinearOperator, /) -> _SumLinearOperator: ...
-    def __neg__(self, /) -> _ScaledLinearOperator: ...
-    def __sub__(self, x: LinearOperator, /) -> _SumLinearOperator: ...
-    def adjoint(self, /) -> _AdjointLinearOperator: ...
+    #
     @property
-    def H(self, /) -> _AdjointLinearOperator: ...
-    def transpose(self, /) -> _TransposedLinearOperator: ...
+    def H(self, /) -> _AdjointLinearOperator[_SCT_co]: ...
+    def adjoint(self, /) -> _AdjointLinearOperator[_SCT_co]: ...
     @property
-    def T(self, /) -> _TransposedLinearOperator: ...
+    def T(self, /) -> _TransposedLinearOperator[_SCT_co]: ...
+    def transpose(self, /) -> _TransposedLinearOperator[_SCT_co]: ...
 
-class _CustomLinearOperator(LinearOperator):
-    args: UntypedTuple
+    #
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self: ...
+
+    #
+    @overload
+    def __init__(self, /, dtype: _ToDType[_SCT_co], shape: _ToShape) -> None: ...
+    @overload
+    def __init__(self: LinearOperator[np.float64], /, dtype: onp.AnyFloat64DType | type[float], shape: _ToShape) -> None: ...
+    @overload
+    def __init__(
+        self: LinearOperator[np.complex128],
+        /,
+        dtype: onp.AnyComplex128DType | type[_JustComplex],
+        shape: _ToShape,
+    ) -> None: ...
+    @overload
+    def __init__(self, /, dtype: onp.AnyInexactDType | None, shape: _ToShape) -> None: ...
+
+    #
+    @overload  # float array 1d
+    def matvec(self, /, x: onp.ToFloatStrict1D) -> onp.Array1D[_SCT_co]: ...
+    @overload  # float matrix
+    def matvec(self, /, x: _Matrix[np.floating[Any] | np.integer[Any]]) -> _Matrix[_SCT_co]: ...
+    @overload  # float array 2d
+    def matvec(self, /, x: onp.ToFloatStrict2D) -> onp.Array2D[_SCT_co]: ...
+    @overload  # complex array 1d
+    def matvec(self, /, x: onp.ToComplexStrict1D) -> onp.Array1D[_SCT_co | np.complex128]: ...
+    @overload  # complex matrix
+    def matvec(self, /, x: _Matrix[np.number[Any]]) -> _Matrix[_SCT_co | np.complex128]: ...
+    @overload  # complex array 2d
+    def matvec(self, /, x: onp.ToComplexStrict2D) -> onp.Array2D[_SCT_co | np.complex128]: ...
+    @overload  # float array
+    def matvec(self, /, x: onp.ToFloat2D) -> onp.Array1D[_SCT_co] | onp.Array2D[_SCT_co]: ...
+    @overload  # complex array
+    def matvec(self, /, x: onp.ToComplex2D) -> onp.Array1D[_SCT_co | np.complex128] | onp.Array2D[_SCT_co | np.complex128]: ...
+    rmatvec = matvec
+
+    #
+    def matmat(self, /, X: onp.ToComplex2D) -> onp.Array[tuple[int, int], _SCT_co | np.complex128]: ...
+    rmatmat = matmat
+
+    #
+    @overload
+    def dot(self, /, x: LinearOperator[_SCT]) -> _ProductLinearOperator[_SCT_co, _SCT]: ...
+    @overload
+    def dot(self, /, x: onp.ToFloat) -> _ScaledLinearOperator[_SCT_co]: ...
+    @overload
+    def dot(self, /, x: onp.ToComplex) -> _ScaledLinearOperator: ...
+    @overload
+    def dot(self, /, x: onp.ToFloatStrict1D) -> onp.Array1D[_SCT_co]: ...
+    @overload
+    def dot(self, /, x: onp.ToComplexStrict1D) -> onp.Array1D[_SCT_co | np.complex128]: ...
+    @overload
+    def dot(self, /, x: onp.ToFloatStrict2D) -> onp.Array2D[_SCT_co]: ...
+    @overload
+    def dot(self, /, x: onp.ToComplexStrict2D) -> onp.Array2D[_SCT_co | np.complex128]: ...
+    @overload
+    def dot(self, /, x: onp.ToFloatND) -> onp.Array1D[_SCT_co] | onp.Array2D[_SCT_co]: ...
+    @overload
+    def dot(self, /, x: onp.ToComplexND) -> onp.Array1D[_SCT_co | np.complex128] | onp.Array2D[_SCT_co | np.complex128]: ...
+    __mul__ = dot
+    __rmul__ = dot
+    __call__ = dot
+
+    #
+    @overload
+    def __matmul__(self, /, x: LinearOperator[_SCT]) -> _ProductLinearOperator[_SCT_co, _SCT]: ...
+    @overload
+    def __matmul__(self, /, x: onp.ToFloatStrict1D) -> onp.Array1D[_SCT_co]: ...
+    @overload
+    def __matmul__(self, /, x: onp.ToComplexStrict1D) -> onp.Array1D[_SCT_co | np.complex128]: ...
+    @overload
+    def __matmul__(self, /, x: onp.ToFloatStrict2D) -> onp.Array2D[_SCT_co]: ...
+    @overload
+    def __matmul__(self, /, x: onp.ToComplexStrict2D) -> onp.Array2D[_SCT_co | np.complex128]: ...
+    @overload
+    def __matmul__(self, /, x: onp.ToFloatND) -> onp.Array1D[_SCT_co] | onp.Array2D[_SCT_co]: ...
+    @overload
+    def __matmul__(
+        self,
+        /,
+        x: onp.ToComplexND,
+    ) -> onp.Array1D[_SCT_co | np.complex128] | onp.Array2D[_SCT_co | np.complex128]: ...
+    __rmatmul__ = __matmul__
+
+    #
+    @overload
+    def __truediv__(self, other: onp.ToFloat, /) -> _ScaledLinearOperator[_SCT_co]: ...
+    @overload
+    def __truediv__(self, other: onp.ToComplex, /) -> _ScaledLinearOperator[_SCT_co | np.complex128]: ...
+
+    #
+    def __neg__(self, /) -> _ScaledLinearOperator[_SCT_co]: ...
+    def __add__(self, x: LinearOperator[_SCT], /) -> _SumLinearOperator[_SCT_co, _SCT]: ...
+    __sub__ = __add__
+    def __pow__(self, p: onp.ToInt, /) -> _PowerLinearOperator[_SCT_co]: ...
+
+@final
+class _CustomLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co, _FunMatVecT_co]):
+    args: tuple[()]
+
+    @overload  # no dtype
     def __init__(
         self,
         /,
-        shape: Untyped,
-        matvec: Untyped,
-        rmatvec: Untyped | None = None,
-        matmat: Untyped | None = None,
-        dtype: Untyped | None = None,
-        rmatmat: Untyped | None = None,
+        shape: _ToShape,
+        matvec: _FunMatVec,
+        rmatvec: _FunMatVec | None = None,
+        matmat: _FunMatMat | None = None,
+        dtype: None = None,
+        rmatmat: _FunMatMat | None = None,
+    ) -> None: ...
+    @overload  # dtype known (positional)
+    def __init__(
+        self,
+        /,
+        shape: _ToShape,
+        matvec: _FunMatVec,
+        rmatvec: _FunMatVec | None,
+        matmat: _FunMatMat | None,
+        dtype: _ToDType[_SCT_co],
+        rmatmat: _FunMatMat | None = None,
+    ) -> None: ...
+    @overload  # dtype known (keyword)
+    def __init__(
+        self,
+        /,
+        shape: _ToShape,
+        matvec: _FunMatVec,
+        rmatvec: _FunMatVec | None = None,
+        matmat: _FunMatMat | None = None,
+        *,
+        dtype: _ToDType[_SCT_co],
+        rmatmat: _FunMatMat | None = None,
+    ) -> None: ...
+    @overload  # dtype-like float64 (positional)
+    def __init__(
+        self: _CustomLinearOperator[np.float64],
+        /,
+        shape: _ToShape,
+        matvec: _FunMatVec,
+        rmatvec: _FunMatVec | None,
+        matmat: _FunMatMat | None,
+        dtype: onp.AnyFloat64DType | type[float],
+        rmatmat: _FunMatMat | None = None,
+    ) -> None: ...
+    @overload  # dtype-like float64 (keyword)
+    def __init__(
+        self: _CustomLinearOperator[np.float64],
+        /,
+        shape: _ToShape,
+        matvec: _FunMatVec,
+        rmatvec: _FunMatVec | None = None,
+        matmat: _FunMatMat | None = None,
+        *,
+        dtype: onp.AnyFloat64DType | type[float],
+        rmatmat: _FunMatMat | None = None,
+    ) -> None: ...
+    @overload  # dtype-like complex128 (positional)
+    def __init__(
+        self: _CustomLinearOperator[np.complex128],
+        /,
+        shape: _ToShape,
+        matvec: _FunMatVec,
+        rmatvec: _FunMatVec | None,
+        matmat: _FunMatMat | None,
+        dtype: onp.AnyComplex128DType | type[opt.Just[complex]],
+        rmatmat: _FunMatMat | None = None,
+    ) -> None: ...
+    @overload  # dtype-like complex128 (keyword)
+    def __init__(
+        self: _CustomLinearOperator[np.complex128],
+        /,
+        shape: _ToShape,
+        matvec: _FunMatVec,
+        rmatvec: _FunMatVec | None = None,
+        matmat: _FunMatMat | None = None,
+        *,
+        dtype: onp.AnyComplex128DType | type[opt.Just[complex]],
+        rmatmat: _FunMatMat | None = None,
     ) -> None: ...
 
-class _AdjointLinearOperator(LinearOperator):
-    A: LinearOperator
-    args: tuple[LinearOperator]
-    def __init__(self, /, A: LinearOperator) -> None: ...
+@type_check_only
+class _UnaryLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
+    A: LinearOperator[_SCT_co]
+    args: tuple[LinearOperator[_SCT_co]]
+    def __init__(self, /, A: LinearOperator[_SCT_co]) -> None: ...
 
-class _TransposedLinearOperator(LinearOperator):
-    A: LinearOperator
-    args: tuple[LinearOperator]
-    def __init__(self, /, A: LinearOperator) -> None: ...
+@final
+class _AdjointLinearOperator(_UnaryLinearOperator[_SCT_co], Generic[_SCT_co]): ...
 
-class _SumLinearOperator(LinearOperator):
-    args: tuple[LinearOperator, LinearOperator]
-    def __init__(self, /, A: LinearOperator, B: LinearOperator) -> None: ...
+@final
+class _TransposedLinearOperator(_UnaryLinearOperator[_SCT_co], Generic[_SCT_co]): ...
 
-class _ProductLinearOperator(LinearOperator):
-    args: tuple[LinearOperator, LinearOperator]
-    def __init__(self, /, A: LinearOperator, B: LinearOperator) -> None: ...
+@final
+class _SumLinearOperator(LinearOperator[_SCT1_co | _SCT2_co], Generic[_SCT1_co, _SCT2_co]):
+    args: tuple[LinearOperator[_SCT1_co], LinearOperator[_SCT2_co]]
+    def __init__(self, /, A: LinearOperator[_SCT1_co], B: LinearOperator[_SCT2_co]) -> None: ...
 
-class _ScaledLinearOperator(LinearOperator):
-    args: tuple[LinearOperator, onp.ToScalar]
-    def __init__(self, /, A: LinearOperator, alpha: onp.ToScalar) -> None: ...
+@final
+class _ProductLinearOperator(LinearOperator[_SCT1_co | _SCT2_co], Generic[_SCT1_co, _SCT2_co]):
+    args: tuple[LinearOperator[_SCT1_co], LinearOperator[_SCT2_co]]
+    def __init__(self, /, A: LinearOperator[_SCT1_co], B: LinearOperator[_SCT2_co]) -> None: ...
 
-class _PowerLinearOperator(LinearOperator):
-    args: tuple[LinearOperator, onp.ToInt]
-    def __init__(self, /, A: LinearOperator, p: onp.ToInt) -> None: ...
+@final
+class _ScaledLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
+    args: tuple[LinearOperator[_SCT_co], _SCT_co | complex]
+    @overload
+    def __init__(self, /, A: LinearOperator[_SCT_co], alpha: _SCT_co | complex) -> None: ...
+    @overload
+    def __init__(self: _ScaledLinearOperator[np.float64], /, A: LinearOperator[np.floating[Any]], alpha: float) -> None: ...
+    @overload
+    def __init__(self: _ScaledLinearOperator[np.complex128], /, A: LinearOperator, alpha: complex) -> None: ...
 
-class MatrixLinearOperator(LinearOperator):
-    A: LinearOperator
-    args: tuple[LinearOperator]
-    def __init__(self, /, A: LinearOperator) -> None: ...
+@final
+class _PowerLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
+    args: tuple[LinearOperator[_SCT_co], op.CanIndex]
+    def __init__(self, /, A: LinearOperator[_SCT_co], p: op.CanIndex) -> None: ...
 
-class _AdjointMatrixOperator(MatrixLinearOperator):
-    A: LinearOperator
-    args: tuple[LinearOperator]
-    shape: tuple[int, int]  # pyright: ignore[reportIncompatibleVariableOverride]
+class MatrixLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
+    A: _spbase | onp.Array2D[_SCT_co]
+    args: tuple[_spbase | onp.Array2D[_SCT_co]]
+    def __init__(self, /, A: _spbase | onp.ArrayND[_SCT_co]) -> None: ...
+
+@final
+class _AdjointMatrixOperator(MatrixLinearOperator[_SCT_co], Generic[_SCT_co]):
+    args: tuple[MatrixLinearOperator[_SCT_co]]  # type: ignore[assignment]
     @property
     @override
-    def dtype(self, /) -> np.dtype[np.generic]: ...  # type: ignore[override] # pyright: ignore[reportIncompatibleVariableOverride]
+    def dtype(self, /) -> np.dtype[_SCT_co]: ...
     def __init__(self, /, adjoint: LinearOperator) -> None: ...
 
-class IdentityOperator(LinearOperator):
-    def __init__(self, /, shape: Untyped, dtype: Untyped | None = None) -> None: ...
+class IdentityOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
+    @overload
+    def __init__(self, /, shape: _ToShape, dtype: _ToDType[_SCT_co]) -> None: ...
+    @overload
+    def __init__(
+        self: IdentityOperator[np.float64],
+        /,
+        shape: _ToShape,
+        dtype: onp.AnyFloat64DType | type[float] | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: IdentityOperator[np.complex128],
+        /,
+        shape: _ToShape,
+        dtype: onp.AnyComplex128DType | type[_JustComplex],
+    ) -> None: ...
+    @overload
+    def __init__(self, /, shape: _ToShape, dtype: onp.AnyInexactDType) -> None: ...
 
-def aslinearoperator(A: Untyped) -> Untyped: ...
+@type_check_only
+class _HasShapeAndMatVec(Protocol[_SCT_co]):
+    shape: tuple[int, int]
+    @overload
+    def matvec(self, /, x: onp.CanArray1D[np.float64]) -> onp.CanArray1D[_SCT_co]: ...
+    @overload
+    def matvec(self, /, x: onp.CanArray1D[np.complex128]) -> onp.ToComplex1D: ...
+    @overload
+    def matvec(self, /, x: onp.CanArray2D[np.float64]) -> onp.CanArray2D[_SCT_co]: ...
+    @overload
+    def matvec(self, /, x: onp.CanArray2D[np.complex128]) -> onp.ToComplex2D: ...
+
+@type_check_only
+class _HasShapeAndDTypeAndMatVec(Protocol[_SCT_co]):
+    shape: tuple[int, int]
+    @property
+    def dtype(self) -> np.dtype[_SCT_co]: ...
+    @overload
+    def matvec(self, /, x: onp.CanArray1D[np.float64] | onp.CanArray1D[np.complex128]) -> onp.ToComplex1D: ...
+    @overload
+    def matvec(self, /, x: onp.CanArray2D[np.float64] | onp.CanArray2D[np.complex128]) -> onp.ToComplex2D: ...
+
+@overload
+def aslinearoperator(A: onp.CanArrayND[_SCT_co]) -> MatrixLinearOperator[_SCT_co]: ...
+@overload
+def aslinearoperator(A: _spbase) -> MatrixLinearOperator: ...
+@overload
+def aslinearoperator(A: onp.ArrayND[np.integer[Any] | np.bool_]) -> MatrixLinearOperator[np.float64]: ...
+@overload
+def aslinearoperator(A: _HasShapeAndDTypeAndMatVec[_SCT_co]) -> MatrixLinearOperator[_SCT_co]: ...
+@overload
+def aslinearoperator(A: _HasShapeAndMatVec[_SCT_co]) -> MatrixLinearOperator[_SCT_co]: ...


### PR DESCRIPTION
This affects the following public `scipy.sparse.linalg` members:

- `LinearOperator`
- `aslinearoperator`

towards #100 (-26)