### PR TITLE
✨ `sparse.linalg`: complete `_eigen.arpack`

### DIFF
--- a/scipy-stubs/sparse/linalg/_eigen/arpack/arpack.pyi
+++ b/scipy-stubs/sparse/linalg/_eigen/arpack/arpack.pyi
@@ -1,93 +1,139 @@
-from typing import Final
-from typing_extensions import override
+from collections.abc import Mapping
+from typing import Any, Final, Literal, TypeAlias, TypeVar, overload
 
 import numpy as np
-from scipy._typing import Untyped
-from scipy.sparse.linalg._interface import LinearOperator
+import optype.numpy as onp
+from scipy.sparse._base import _spbase
+from scipy.sparse.linalg import LinearOperator
 
 __all__ = ["ArpackError", "ArpackNoConvergence", "eigs", "eigsh"]
 
-DNAUPD_ERRORS: Final[dict[int, str]]
-SNAUPD_ERRORS = DNAUPD_ERRORS
-ZNAUPD_ERRORS: Final[dict[int, str]]
-CNAUPD_ERRORS = ZNAUPD_ERRORS
-DSAUPD_ERRORS: Final[dict[int, str]]
-SSAUPD_ERRORS = DSAUPD_ERRORS
-DNEUPD_ERRORS: Final[dict[int, str]]
-SNEUPD_ERRORS: Final[dict[int, str]]
-ZNEUPD_ERRORS: Final[dict[int, str]]
-CNEUPD_ERRORS: Final[dict[int, str]]
-DSEUPD_ERRORS: Final[dict[int, str]]
-SSEUPD_ERRORS: Final[dict[int, str]]
+_KT = TypeVar("_KT")
+
+_Falsy: TypeAlias = Literal[False, 0]
+_Truthy: TypeAlias = Literal[True, 1]
+
+_ToRealMatrix: TypeAlias = onp.ToFloat2D | LinearOperator[np.floating[Any] | np.integer[Any]] | _spbase
+_ToComplexMatrix: TypeAlias = onp.ToComplex2D | LinearOperator | _spbase
+
+_Which: TypeAlias = Literal["LM", "SM", "LR", "SR", "LI", "SI"]
+_OPpart: TypeAlias = Literal["r", "i"]
+_Mode: TypeAlias = Literal["normal", "buckling", "cayley"]
+
+###
 
 class ArpackError(RuntimeError):
-    def __init__(self, /, info: Untyped, infodict: Untyped = ...) -> None: ...
+    def __init__(self, /, info: _KT, infodict: Mapping[_KT, str] = ...) -> None: ...
 
 class ArpackNoConvergence(ArpackError):
-    eigenvalues: Untyped
-    eigenvectors: Untyped
-    def __init__(self, /, msg: Untyped, eigenvalues: Untyped, eigenvectors: Untyped) -> None: ...
+    eigenvalues: Final[onp.Array1D[np.float64 | np.float128]]
+    eigenvectors: Final[onp.Array2D[np.float64]]
+    def __init__(
+        self,
+        /,
+        msg: str,
+        eigenvalues: onp.Array1D[np.float64 | np.float128],
+        eigenvectors: onp.Array2D[np.float64],
+    ) -> None: ...
 
-def choose_ncv(k: Untyped) -> Untyped: ...
-
-class SpLuInv(LinearOperator):
-    M_lu: Untyped
-    isreal: Untyped
-    def __init__(self, /, M: Untyped) -> None: ...
-
-class LuInv(LinearOperator):
-    M_lu: Untyped
-    def __init__(self, /, M: Untyped) -> None: ...
-
-def gmres_loose(A: Untyped, b: Untyped, tol: Untyped) -> Untyped: ...
-
-class IterInv(LinearOperator):
-    M: Untyped
-    ifunc: Untyped
-    tol: Untyped
-    def __init__(self, /, M: Untyped, ifunc: Untyped = ..., tol: float = 0) -> None: ...
-
-class IterOpInv(LinearOperator):
-    A: Untyped
-    M: Untyped
-    sigma: Untyped
-    OP: Untyped
-    ifunc: Untyped
-    tol: Untyped
-    @property
-    @override
-    def dtype(self, /) -> np.dtype[np.generic]: ...  # type: ignore[override] # pyright: ignore[reportIncompatibleVariableOverride]
-    def __init__(self, /, A: Untyped, M: Untyped, sigma: Untyped, ifunc: Untyped = ..., tol: float = 0) -> None: ...
-
-def get_inv_matvec(M: Untyped, hermitian: bool = False, tol: float = 0) -> Untyped: ...
-def get_OPinv_matvec(A: Untyped, M: Untyped, sigma: Untyped, hermitian: bool = False, tol: float = 0) -> Untyped: ...
+#
+@overload  # returns_eigenvectors: truthy (default)
 def eigs(
-    A: Untyped,
+    A: _ToComplexMatrix,
     k: int = 6,
-    M: Untyped | None = None,
-    sigma: Untyped | None = None,
-    which: str = "LM",
-    v0: Untyped | None = None,
-    ncv: Untyped | None = None,
-    maxiter: Untyped | None = None,
+    M: _ToRealMatrix | None = None,
+    sigma: onp.ToComplex | None = None,
+    which: _Which = "LM",
+    v0: onp.ToFloat1D | None = None,
+    ncv: int | None = None,
+    maxiter: int | None = None,
     tol: float = 0,
-    return_eigenvectors: bool = True,
-    Minv: Untyped | None = None,
-    OPinv: Untyped | None = None,
-    OPpart: Untyped | None = None,
-) -> Untyped: ...
+    return_eigenvectors: _Truthy = True,
+    Minv: _ToRealMatrix | None = None,
+    OPinv: _ToRealMatrix | None = None,
+    OPpart: _OPpart | None = None,
+) -> tuple[onp.Array1D[np.complex128], onp.Array2D[np.float64]]: ...
+@overload  # returns_eigenvectors: falsy (positional)
+def eigs(
+    A: _ToComplexMatrix,
+    k: int,
+    M: _ToRealMatrix | None,
+    sigma: onp.ToComplex | None,
+    which: _Which,
+    v0: onp.ToFloat1D | None,
+    ncv: int | None,
+    maxiter: int | None,
+    tol: float,
+    return_eigenvectors: _Falsy,
+    Minv: _ToRealMatrix | None = None,
+    OPinv: _ToRealMatrix | None = None,
+    OPpart: _OPpart | None = None,
+) -> onp.Array1D[np.complex128]: ...
+@overload  # returns_eigenvectors: falsy (keyword)
+def eigs(
+    A: _ToComplexMatrix,
+    k: int = 6,
+    M: _ToRealMatrix | None = None,
+    sigma: onp.ToComplex | None = None,
+    which: _Which = "LM",
+    v0: onp.ToFloat1D | None = None,
+    ncv: int | None = None,
+    maxiter: int | None = None,
+    tol: float = 0,
+    *,
+    return_eigenvectors: _Falsy,
+    Minv: _ToRealMatrix | None = None,
+    OPinv: _ToRealMatrix | None = None,
+    OPpart: _OPpart | None = None,
+) -> onp.Array1D[np.complex128]: ...
+
+#
+@overload  # returns_eigenvectors: truthy (default)
 def eigsh(
-    A: Untyped,
+    A: _ToComplexMatrix,
     k: int = 6,
-    M: Untyped | None = None,
-    sigma: Untyped | None = None,
-    which: str = "LM",
-    v0: Untyped | None = None,
-    ncv: Untyped | None = None,
-    maxiter: Untyped | None = None,
+    M: _ToRealMatrix | None = None,
+    sigma: onp.ToComplex | None = None,
+    which: _Which = "LM",
+    v0: onp.ToFloat1D | None = None,
+    ncv: int | None = None,
+    maxiter: int | None = None,
     tol: float = 0,
-    return_eigenvectors: bool = True,
-    Minv: Untyped | None = None,
-    OPinv: Untyped | None = None,
-    mode: str = "normal",
-) -> Untyped: ...
+    return_eigenvectors: _Truthy = True,
+    Minv: _ToRealMatrix | None = None,
+    OPinv: _ToRealMatrix | None = None,
+    mode: _Mode = "normal",
+) -> tuple[onp.Array1D[np.float64], onp.Array2D[np.float64]]: ...
+@overload  # returns_eigenvectors: falsy (positional)
+def eigsh(
+    A: _ToComplexMatrix,
+    k: int,
+    M: _ToRealMatrix | None,
+    sigma: onp.ToComplex | None,
+    which: _Which,
+    v0: onp.ToFloat1D | None,
+    ncv: int | None,
+    maxiter: int | None,
+    tol: float,
+    return_eigenvectors: _Falsy,
+    Minv: _ToRealMatrix | None = None,
+    OPinv: _ToRealMatrix | None = None,
+    mode: _Mode = "normal",
+) -> onp.Array1D[np.float64]: ...
+@overload  # returns_eigenvectors: falsy (keyword)
+def eigsh(
+    A: _ToComplexMatrix,
+    k: int = 6,
+    M: _ToRealMatrix | None = None,
+    sigma: onp.ToComplex | None = None,
+    which: _Which = "LM",
+    v0: onp.ToFloat1D | None = None,
+    ncv: int | None = None,
+    maxiter: int | None = None,
+    tol: float = 0,
+    *,
+    return_eigenvectors: _Falsy,
+    Minv: _ToRealMatrix | None = None,
+    OPinv: _ToRealMatrix | None = None,
+    mode: _Mode = "normal",
+) -> onp.Array1D[np.float64]: ...


### PR DESCRIPTION
This affects the following public members of [`scipy.sparse.linalg`](https://docs.scipy.org/doc/scipy-1.14.1/reference/sparse.linalg.html):

- `eigs`
- `eigsh`
- `ArpackError`
- `ArpackNoConvergence`

towards #100 (-59)