### PR TITLE
✨ `sparse`: complete the remaining `sparse.linalg` functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,13 +177,13 @@ from 🌑 (100% `Untyped`) to 🌕 (0% `Untyped`).
 | `odr`         |          ✔️           |     ✔️     |     ✔️      |       ✔️       |  🌕   |
 | `optimize`    |          ✔️           |     ✔️     |     ✔️      |       ✔️       |  🌕   |
 | `signal`      |          ✔️           |     ✔️     |     ✔️      |       ✔️       |  🌔   |
-| `sparse`      |          ✔️           |     ✔️     |     ✔️      |       ✔️       |  🌓   |
+| `sparse`      |          ✔️           |     ✔️     |     ✔️      |       ✔️       |  🌕   |
 | `spatial`     |          ✔️           |     ✔️     |     ✔️      |       ✔️       |  🌕   |
 | `special`     |          ✔️           |     ✔️     |     ✔️      |       ✔️       |  🌕   |
 | `stats`       |          ✔️           |     ✔️     |     ✔️      |       ✔️       |  🌕   |
 | *`_lib`*      |          ✔️           |     ✔️     |     ✔️      |       ✔️       |  🌕   |
 
-Currently, only `signal` and `sparse` contain `Untyped` annotations.
+Currently, only `scipy.signal` contains `Untyped` annotations; all other submodules have complete typing coverage.
 
 ## Podcast (AI generated)
 

--- a/scipy-stubs/sparse/linalg/_isolve/_gcrotmk.pyi
+++ b/scipy-stubs/sparse/linalg/_isolve/_gcrotmk.pyi
@@ -1,20 +1,63 @@
-from scipy._typing import Untyped
+from collections.abc import Callable
+from typing import Any, Literal, TypeAlias, overload
+from typing_extensions import TypeVar
+
+import numpy as np
+import optype.numpy as onp
+from scipy.sparse._base import _spbase
+from scipy.sparse._typing import Scalar
+from scipy.sparse.linalg import LinearOperator
 
 __all__ = ["gcrotmk"]
 
+_Float: TypeAlias = np.float32 | np.float64
+_Complex: TypeAlias = np.complex64 | np.complex128
+
+_FloatT = TypeVar("_FloatT", bound=_Float, default=np.float64)
+_ComplexT = TypeVar("_ComplexT", bound=_Complex, default=np.complex128)
+_ScalarT = TypeVar("_ScalarT", bound=Scalar)
+
+_ToInt: TypeAlias = np.integer[Any] | np.bool_
+_ToLinearOperator: TypeAlias = onp.CanArrayND[_ScalarT] | _spbase[_ScalarT] | LinearOperator[_ScalarT]
+
+_Ignored: TypeAlias = object
+_Callback: TypeAlias = Callable[[onp.Array1D[_ScalarT]], _Ignored]
+
+_Truncate: TypeAlias = Literal["oldest", "newest"]
+
+###
+
+@overload
 def gcrotmk(
-    A: Untyped,
-    b: Untyped,
-    x0: Untyped | None = None,
+    A: _ToLinearOperator[_FloatT | _ToInt],
+    b: onp.ToFloat1D,
+    x0: onp.ToFloat1D | None = None,
     *,
-    rtol: float = 1e-05,
-    atol: float = 0.0,
-    maxiter: int = 1000,
-    M: Untyped | None = None,
-    callback: Untyped | None = None,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[_FloatT | _ToInt] | None = None,
+    callback: _Callback[_FloatT] | None = None,
     m: int = 20,
-    k: Untyped | None = None,
-    CU: Untyped | None = None,
-    discard_C: bool = False,
-    truncate: str = "oldest",
-) -> Untyped: ...
+    k: int | None = None,
+    CU: list[tuple[list[onp.ArrayND[_Float]], list[onp.ArrayND[_Float]] | None]] | None = None,
+    discard_C: onp.ToBool = False,
+    truncate: _Truncate = "oldest",
+) -> tuple[onp.Array1D[_FloatT], int]: ...
+@overload
+def gcrotmk(
+    A: _ToLinearOperator[_ComplexT],
+    b: onp.ToComplex1D,
+    x0: onp.ToComplex1D | None = None,
+    *,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[_ComplexT] | None = None,
+    callback: _Callback[_ComplexT] | None = None,
+    m: int = 20,
+    k: int | None = None,
+    CU: list[tuple[list[onp.ArrayND[_Float | _Complex]], list[onp.ArrayND[_Float | _Complex]] | None]] | None = None,
+    discard_C: onp.ToBool = False,
+    truncate: _Truncate = "oldest",
+) -> tuple[onp.Array1D[_ComplexT], int]: ...

--- a/scipy-stubs/sparse/linalg/_isolve/iterative.pyi
+++ b/scipy-stubs/sparse/linalg/_isolve/iterative.pyi
@@ -1,6 +1,32 @@
+from collections.abc import Callable
+from typing import Any, TypeAlias, TypeVar, overload
+
+import numpy as np
+import optype.numpy as onp
 from scipy._typing import Untyped
+from scipy.sparse._base import _spbase
+from scipy.sparse._typing import Scalar
+from scipy.sparse.linalg import LinearOperator
 
 __all__ = ["bicg", "bicgstab", "cg", "cgs", "gmres", "qmr"]
+
+_Float: TypeAlias = np.float32 | np.float64
+_Complex: TypeAlias = np.complex64 | np.complex128
+
+_ToInt: TypeAlias = np.integer[Any] | np.bool_
+_ToFloat: TypeAlias = _Float | _ToInt
+_ToComplex: TypeAlias = _Complex | _ToFloat
+
+_FloatT = TypeVar("_FloatT", bound=_Float, default=np.float64)
+_ComplexT = TypeVar("_ComplexT", bound=_Complex)
+_ScalarT = TypeVar("_ScalarT", bound=Scalar)
+
+_ToLinearOperator: TypeAlias = onp.CanArrayND[_ScalarT] | _spbase[_ScalarT] | LinearOperator[_ScalarT]
+
+_Ignored: TypeAlias = object
+_Callback: TypeAlias = Callable[[onp.Array1D[_ScalarT]], _Ignored]
+
+###
 
 def bicg(
     A: Untyped,
@@ -9,7 +35,7 @@ def bicg(
     *,
     rtol: float = 1e-05,
     atol: float = 0.0,
-    maxiter: Untyped | None = None,
+    maxiter: int | None = None,
     M: Untyped | None = None,
     callback: Untyped | None = None,
 ) -> Untyped: ...
@@ -20,10 +46,12 @@ def bicgstab(
     *,
     rtol: float = 1e-05,
     atol: float = 0.0,
-    maxiter: Untyped | None = None,
+    maxiter: int | None = None,
     M: Untyped | None = None,
     callback: Untyped | None = None,
 ) -> Untyped: ...
+
+#
 def cg(
     A: Untyped,
     b: Untyped,
@@ -31,7 +59,7 @@ def cg(
     *,
     rtol: float = 1e-05,
     atol: float = 0.0,
-    maxiter: Untyped | None = None,
+    maxiter: int | None = None,
     M: Untyped | None = None,
     callback: Untyped | None = None,
 ) -> Untyped: ...
@@ -42,10 +70,12 @@ def cgs(
     *,
     rtol: float = 1e-05,
     atol: float = 0.0,
-    maxiter: Untyped | None = None,
+    maxiter: int | None = None,
     M: Untyped | None = None,
     callback: Untyped | None = None,
 ) -> Untyped: ...
+
+#
 def gmres(
     A: Untyped,
     b: Untyped,
@@ -54,20 +84,36 @@ def gmres(
     rtol: float = 1e-05,
     atol: float = 0.0,
     restart: Untyped | None = None,
-    maxiter: Untyped | None = None,
+    maxiter: int | None = None,
     M: Untyped | None = None,
     callback: Untyped | None = None,
     callback_type: Untyped | None = None,
 ) -> Untyped: ...
+
+#
+@overload  # real
 def qmr(
-    A: Untyped,
-    b: Untyped,
-    x0: Untyped | None = None,
+    A: _ToLinearOperator[_FloatT | _ToInt],
+    b: onp.ToFloat1D,
+    x0: onp.ToFloat1D | None = None,
     *,
-    rtol: float = 1e-05,
-    atol: float = 0.0,
-    maxiter: Untyped | None = None,
-    M1: Untyped | None = None,
-    M2: Untyped | None = None,
-    callback: Untyped | None = None,
-) -> Untyped: ...
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    maxiter: int | None = None,
+    M1: _ToLinearOperator[_ToFloat] | None = None,
+    M2: _ToLinearOperator[_ToFloat] | None = None,
+    callback: _Callback[_FloatT] | None = None,
+) -> tuple[onp.Array1D[_FloatT], int]: ...
+@overload  # complex
+def qmr(
+    A: _ToLinearOperator[_ComplexT],
+    b: onp.ToComplex1D,
+    x0: onp.ToComplex1D | None = None,
+    *,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    maxiter: int | None = None,
+    M1: _ToLinearOperator[_ToComplex] | None = None,
+    M2: _ToLinearOperator[_ToComplex] | None = None,
+    callback: _Callback[_ComplexT] | None = None,
+) -> tuple[onp.Array1D[_ComplexT], int]: ...

--- a/scipy-stubs/sparse/linalg/_isolve/iterative.pyi
+++ b/scipy-stubs/sparse/linalg/_isolve/iterative.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, TypeAlias, TypeVar, overload
+from typing import Any, Literal, TypeAlias, TypeVar, overload
 
 import numpy as np
 import optype.numpy as onp
@@ -76,19 +76,62 @@ def cgs(
 ) -> Untyped: ...
 
 #
+@overload  # real, callback_type: {"pr_norm", "legacy"} | None = ...
 def gmres(
-    A: Untyped,
-    b: Untyped,
-    x0: Untyped | None = None,
+    A: _ToLinearOperator[_FloatT | _ToInt],
+    b: onp.ToFloat1D,
+    x0: onp.ToFloat1D | None = None,
     *,
-    rtol: float = 1e-05,
-    atol: float = 0.0,
-    restart: Untyped | None = None,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    restart: int | None = None,
     maxiter: int | None = None,
-    M: Untyped | None = None,
-    callback: Untyped | None = None,
-    callback_type: Untyped | None = None,
-) -> Untyped: ...
+    M: _ToLinearOperator[_ToFloat] | None = None,
+    callback: Callable[[float], _Ignored] | Callable[[np.float64], _Ignored] | None = None,
+    callback_type: Literal["pr_norm", "legacy"] | None = ...,
+) -> tuple[onp.Array1D[_FloatT], int]: ...
+@overload  # real, callback_type: {"x"}
+def gmres(
+    A: _ToLinearOperator[_FloatT | _ToInt],
+    b: onp.ToFloat1D,
+    x0: onp.ToFloat1D | None = None,
+    *,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    restart: int | None = None,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[_ToFloat] | None = None,
+    callback: _Callback[_FloatT] | None = None,
+    callback_type: Literal["x"],
+) -> tuple[onp.Array1D[_FloatT], int]: ...
+@overload  # complex, callback_type: {"pr_norm", "legacy"} | None = ...
+def gmres(
+    A: _ToLinearOperator[_ComplexT],
+    b: onp.ToComplex1D,
+    x0: onp.ToComplex1D | None = None,
+    *,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    restart: int | None = None,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[_ToFloat] | None = None,
+    callback: Callable[[float], _Ignored] | Callable[[np.float64], _Ignored] | None = None,
+    callback_type: Literal["pr_norm", "legacy"] | None = ...,
+) -> tuple[onp.Array1D[_ComplexT], int]: ...
+@overload  # complex, callback_type: {"x"}
+def gmres(
+    A: _ToLinearOperator[_ComplexT],
+    b: onp.ToComplex1D,
+    x0: onp.ToComplex1D | None = None,
+    *,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    restart: int | None = None,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[_ToComplex] | None = None,
+    callback: _Callback[_ComplexT] | None = None,
+    callback_type: Literal["x"],
+) -> tuple[onp.Array1D[_ComplexT], int]: ...
 
 #
 @overload  # real

--- a/scipy-stubs/sparse/linalg/_isolve/iterative.pyi
+++ b/scipy-stubs/sparse/linalg/_isolve/iterative.pyi
@@ -53,28 +53,43 @@ def bicgstab(
 ) -> Untyped: ...
 
 #
+@overload  # real
 def cg(
-    A: Untyped,
-    b: Untyped,
-    x0: Untyped | None = None,
+    A: _ToLinearOperator[_FloatT | _ToInt],
+    b: onp.ToFloat1D,
+    x0: onp.ToFloat1D | None = None,
     *,
-    rtol: float = 1e-05,
-    atol: float = 0.0,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
     maxiter: int | None = None,
-    M: Untyped | None = None,
-    callback: Untyped | None = None,
-) -> Untyped: ...
+    M: _ToLinearOperator[_FloatT | _ToInt] | None = None,
+    callback: _Callback[_FloatT] | None = None,
+) -> tuple[onp.Array1D[_FloatT], int]: ...
+@overload  # complex
+def cg(
+    A: _ToLinearOperator[_ComplexT],
+    b: onp.ToComplex1D,
+    x0: onp.ToComplex1D | None = None,
+    *,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[_ComplexT] | None = None,
+    callback: _Callback[_ComplexT] | None = None,
+) -> tuple[onp.Array1D[_ComplexT], int]: ...
+
+#
 def cgs(
-    A: Untyped,
-    b: Untyped,
-    x0: Untyped | None = None,
+    A: _ToLinearOperator[_FloatT | _ToInt],
+    b: onp.ToFloat1D,
+    x0: onp.ToFloat1D | None = None,
     *,
-    rtol: float = 1e-05,
-    atol: float = 0.0,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
     maxiter: int | None = None,
-    M: Untyped | None = None,
-    callback: Untyped | None = None,
-) -> Untyped: ...
+    M: _ToLinearOperator[_FloatT | _ToInt] | None = None,
+    callback: _Callback[_FloatT] | None = None,
+) -> tuple[onp.Array1D[_FloatT], int]: ...
 
 #
 @overload  # real, callback_type: {"pr_norm", "legacy"} | None = ...

--- a/scipy-stubs/sparse/linalg/_isolve/iterative.pyi
+++ b/scipy-stubs/sparse/linalg/_isolve/iterative.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias, TypeVar, overload
+from typing import Any, Literal, TypeAlias, overload
+from typing_extensions import TypeVar
 
 import numpy as np
 import optype.numpy as onp

--- a/scipy-stubs/sparse/linalg/_isolve/iterative.pyi
+++ b/scipy-stubs/sparse/linalg/_isolve/iterative.pyi
@@ -4,7 +4,6 @@ from typing_extensions import TypeVar
 
 import numpy as np
 import optype.numpy as onp
-from scipy._typing import Untyped
 from scipy.sparse._base import _spbase
 from scipy.sparse._typing import Scalar
 from scipy.sparse.linalg import LinearOperator
@@ -29,28 +28,56 @@ _Callback: TypeAlias = Callable[[onp.Array1D[_ScalarT]], _Ignored]
 
 ###
 
+@overload  # real
 def bicg(
-    A: Untyped,
-    b: Untyped,
-    x0: Untyped | None = None,
+    A: _ToLinearOperator[_FloatT | _ToInt],
+    b: onp.ToFloat1D,
+    x0: onp.ToFloat1D | None = None,
     *,
-    rtol: float = 1e-05,
-    atol: float = 0.0,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
     maxiter: int | None = None,
-    M: Untyped | None = None,
-    callback: Untyped | None = None,
-) -> Untyped: ...
+    M: _ToLinearOperator[_FloatT | _ToInt] | None = None,
+    callback: _Callback[_FloatT] | None = None,
+) -> tuple[onp.Array1D[_FloatT], int]: ...
+@overload  # complex
+def bicg(
+    A: _ToLinearOperator[_ComplexT],
+    b: onp.ToComplex1D,
+    x0: onp.ToComplex1D | None = None,
+    *,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[_ComplexT] | None = None,
+    callback: _Callback[_ComplexT] | None = None,
+) -> tuple[onp.Array1D[_ComplexT], int]: ...
+
+#
+@overload  # real
 def bicgstab(
-    A: Untyped,
-    b: Untyped,
-    x0: Untyped | None = None,
+    A: _ToLinearOperator[_FloatT | _ToInt],
+    b: onp.ToFloat1D,
+    x0: onp.ToFloat1D | None = None,
     *,
-    rtol: float = 1e-05,
-    atol: float = 0.0,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
     maxiter: int | None = None,
-    M: Untyped | None = None,
-    callback: Untyped | None = None,
-) -> Untyped: ...
+    M: _ToLinearOperator[_FloatT | _ToInt] | None = None,
+    callback: _Callback[_FloatT] | None = None,
+) -> tuple[onp.Array1D[_FloatT], int]: ...
+@overload  # complex
+def bicgstab(
+    A: _ToLinearOperator[_ComplexT],
+    b: onp.ToComplex1D,
+    x0: onp.ToComplex1D | None = None,
+    *,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[_ComplexT] | None = None,
+    callback: _Callback[_ComplexT] | None = None,
+) -> tuple[onp.Array1D[_ComplexT], int]: ...
 
 #
 @overload  # real

--- a/scipy-stubs/sparse/linalg/_isolve/lgmres.pyi
+++ b/scipy-stubs/sparse/linalg/_isolve/lgmres.pyi
@@ -1,20 +1,61 @@
-from scipy._typing import Untyped
+from collections.abc import Callable
+from typing import Any, TypeAlias, overload
+from typing_extensions import TypeVar
+
+import numpy as np
+import optype.numpy as onp
+from scipy.sparse._base import _spbase
+from scipy.sparse._typing import Scalar
+from scipy.sparse.linalg import LinearOperator
 
 __all__ = ["lgmres"]
 
+_Float: TypeAlias = np.float32 | np.float64
+_Complex: TypeAlias = np.complex64 | np.complex128
+
+_FloatT = TypeVar("_FloatT", bound=_Float, default=np.float64)
+_ComplexT = TypeVar("_ComplexT", bound=_Complex, default=np.complex128)
+_ScalarT = TypeVar("_ScalarT", bound=Scalar)
+
+_ToInt: TypeAlias = np.integer[Any] | np.bool_
+_ToLinearOperator: TypeAlias = onp.CanArrayND[_ScalarT] | _spbase[_ScalarT] | LinearOperator[_ScalarT]
+
+_Ignored: TypeAlias = object
+_Callback: TypeAlias = Callable[[onp.Array1D[_ScalarT]], _Ignored]
+
+###
+
+@overload
 def lgmres(
-    A: Untyped,
-    b: Untyped,
-    x0: Untyped | None = None,
+    A: _ToLinearOperator[_FloatT | _ToInt],
+    b: onp.ToFloat1D,
+    x0: onp.ToFloat1D | None = None,
     *,
-    rtol: float = 1e-05,
-    atol: float = 0.0,
-    maxiter: int = 1000,
-    M: Untyped | None = None,
-    callback: Untyped | None = None,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[_FloatT | _ToInt] | None = None,
+    callback: _Callback[_FloatT] | None = None,
     inner_m: int = 30,
     outer_k: int = 3,
-    outer_v: Untyped | None = None,
-    store_outer_Av: bool = True,
-    prepend_outer_v: bool = False,
-) -> Untyped: ...
+    outer_v: list[tuple[onp.ArrayND[_Float], onp.ArrayND[_Float] | None]] | None = None,
+    store_outer_Av: onp.ToBool = True,
+    prepend_outer_v: onp.ToBool = False,
+) -> tuple[onp.Array1D[_FloatT], int]: ...
+@overload
+def lgmres(
+    A: _ToLinearOperator[_ComplexT],
+    b: onp.ToComplex1D,
+    x0: onp.ToComplex1D | None = None,
+    *,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[_ComplexT] | None = None,
+    callback: _Callback[_ComplexT] | None = None,
+    inner_m: int = 30,
+    outer_k: int = 3,
+    outer_v: list[tuple[onp.ArrayND[_Float | _Complex], onp.ArrayND[_Complex] | None]] | None = None,
+    store_outer_Av: onp.ToBool = True,
+    prepend_outer_v: onp.ToBool = False,
+) -> tuple[onp.Array1D[_ComplexT], int]: ...

--- a/scipy-stubs/sparse/linalg/_isolve/minres.pyi
+++ b/scipy-stubs/sparse/linalg/_isolve/minres.pyi
@@ -25,7 +25,7 @@ def minres(
     x0: onp.ToFloat1D | None = None,
     *,
     rtol: onp.ToFloat = 1e-5,
-    atol: onp.ToFloat = 0.0,
+    shift: onp.ToFloat = 0.0,
     maxiter: int | None = None,
     M: _ToLinearOperator[_FloatT | _ToInt] | None = None,
     callback: Callable[[onp.Array1D[_FloatT]], _Ignored] | None = None,

--- a/scipy-stubs/sparse/linalg/_isolve/minres.pyi
+++ b/scipy-stubs/sparse/linalg/_isolve/minres.pyi
@@ -1,17 +1,34 @@
-from scipy._typing import Untyped
+from collections.abc import Callable
+from typing import Any, TypeAlias
+from typing_extensions import TypeVar
+
+import numpy as np
+import optype.numpy as onp
+from scipy.sparse._base import _spbase
+from scipy.sparse._typing import Scalar
+from scipy.sparse.linalg import LinearOperator
 
 __all__ = ["minres"]
 
+_FloatT = TypeVar("_FloatT", bound=np.float32 | np.float64, default=np.float64)
+_ScalarT = TypeVar("_ScalarT", bound=Scalar)
+
+_Ignored: TypeAlias = object
+_ToInt: TypeAlias = np.integer[Any] | np.bool_
+_ToLinearOperator: TypeAlias = onp.CanArrayND[_ScalarT] | _spbase[_ScalarT] | LinearOperator[_ScalarT]
+
+###
+
 def minres(
-    A: Untyped,
-    b: Untyped,
-    x0: Untyped | None = None,
+    A: _ToLinearOperator[_FloatT | _ToInt],
+    b: onp.ToFloat1D,
+    x0: onp.ToFloat1D | None = None,
     *,
-    rtol: float = 1e-05,
-    shift: float = 0.0,
-    maxiter: Untyped | None = None,
-    M: Untyped | None = None,
-    callback: Untyped | None = None,
-    show: bool = False,
-    check: bool = False,
-) -> Untyped: ...
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[_FloatT | _ToInt] | None = None,
+    callback: Callable[[onp.Array1D[_FloatT]], _Ignored] | None = None,
+    show: onp.ToBool = False,
+    check: onp.ToBool = False,
+) -> tuple[onp.Array1D[_FloatT], int]: ...

--- a/scipy-stubs/sparse/linalg/_isolve/tfqmr.pyi
+++ b/scipy-stubs/sparse/linalg/_isolve/tfqmr.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable
-from typing import Any, TypeAlias, TypeVar, overload
+from typing import Any, TypeAlias, overload
+from typing_extensions import TypeVar
 
 import numpy as np
 import optype.numpy as onp

--- a/scipy-stubs/sparse/linalg/_isolve/tfqmr.pyi
+++ b/scipy-stubs/sparse/linalg/_isolve/tfqmr.pyi
@@ -1,16 +1,48 @@
-from scipy._typing import Untyped
+from collections.abc import Callable
+from typing import Any, TypeAlias, TypeVar, overload
+
+import numpy as np
+import optype.numpy as onp
+from scipy.sparse._base import _spbase
+from scipy.sparse._typing import Scalar
+from scipy.sparse.linalg import LinearOperator
 
 __all__ = ["tfqmr"]
 
+_FloatT = TypeVar("_FloatT", bound=np.float32 | np.float64, default=np.float64)
+_ComplexT = TypeVar("_ComplexT", bound=np.complex64 | np.complex128, default=np.complex128)
+_ScalarT = TypeVar("_ScalarT", bound=Scalar)
+
+_ToLinearOperator: TypeAlias = onp.CanArrayND[_ScalarT] | _spbase[_ScalarT] | LinearOperator[_ScalarT]
+
+_Ignored: TypeAlias = object
+_Callback: TypeAlias = Callable[[onp.Array1D[_ScalarT]], _Ignored]
+
+###
+
+@overload  # real
 def tfqmr(
-    A: Untyped,
-    b: Untyped,
-    x0: Untyped | None = None,
+    A: _ToLinearOperator[_FloatT | np.integer[Any] | np.bool_],
+    b: onp.ToFloat1D,
+    x0: onp.ToFloat1D | None = None,
     *,
-    rtol: float = 1e-05,
-    atol: float = 0.0,
-    maxiter: Untyped | None = None,
-    M: Untyped | None = None,
-    callback: Untyped | None = None,
-    show: bool = False,
-) -> Untyped: ...
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[_FloatT] | None = None,
+    callback: _Callback[_FloatT] | None = None,
+    show: onp.ToBool = False,
+) -> tuple[onp.Array1D[_FloatT], int]: ...
+@overload  # complex
+def tfqmr(
+    A: _ToLinearOperator[_ComplexT],
+    b: onp.ToComplex1D,
+    x0: onp.ToComplex1D | None = None,
+    *,
+    rtol: onp.ToFloat = 1e-5,
+    atol: onp.ToFloat = 0.0,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[_ComplexT] | None = None,
+    callback: _Callback[_ComplexT] | None = None,
+    show: onp.ToBool = False,
+) -> tuple[onp.Array1D[_ComplexT], int]: ...

--- a/scipy-stubs/sparse/linalg/_isolve/utils.pyi
+++ b/scipy-stubs/sparse/linalg/_isolve/utils.pyi
@@ -2,6 +2,7 @@ from typing import Final, Literal, TypeAlias, TypeVar
 
 import numpy as np
 import optype.numpy as onp
+from _typeshed import IdentityFunction
 from scipy.sparse._base import _spbase
 from scipy.sparse._typing import Scalar
 from scipy.sparse.linalg import LinearOperator
@@ -25,4 +26,10 @@ def make_system(
     M: _ToLinearOperator | None,
     x0: onp.ToComplex1D | Literal["Mb"] | None,
     b: onp.ToComplex1D,
-) -> tuple[LinearOperator, LinearOperator, onp.Array1D[_Inexact], onp.Array1D[_Inexact]]: ...
+) -> tuple[
+    LinearOperator,  # A
+    LinearOperator,  # M
+    onp.Array1D[_Inexact],  # x
+    onp.Array1D[_Inexact],  # b
+    IdentityFunction,  # postprocess
+]: ...


### PR DESCRIPTION
This affects the following `scipy.sparse.linalg` public members:

- `gcrotmk`
- `bicg`
- `bicgstab`
- `cg`
- `cgs`
- `gmres`
- `lgmres`
- `minres`
- `qmr`
- `tfqmr`

Closes #100