### PR TITLE
✨ `signal`: complete `_filter_design`, fix and improve `_czt`

### DIFF
--- a/scipy-stubs/signal/_czt.pyi
+++ b/scipy-stubs/signal/_czt.pyi
@@ -1,25 +1,34 @@
-from typing import TypeAlias
+from typing import Any, Final, TypeAlias
 
 import numpy as np
+import optype as op
 import optype.numpy as onp
 
 __all__ = ["CZT", "ZoomFFT", "czt", "czt_points", "zoom_fft"]
 
-_Float: TypeAlias = np.float64 | np.float32
-_Complex: TypeAlias = np.complex128 | np.complex64
+_Complex: TypeAlias = np.complex128 | np.clongdouble
 
+###
+
+# TODO: make generic on `_Complex`
 class CZT:
-    def __init__(self, /, n: int, m: int | None = None, w: onp.ToComplex | None = None, a: onp.ToComplex = 1 + 0j) -> None: ...
+    w: Final[onp.ToComplex]
+    a: Final[onp.ToComplex]
+    m: Final[int | np.integer[Any]]
+    n: Final[int | np.integer[Any]]
+
+    def __init__(
+        self,
+        /,
+        n: onp.ToJustInt,
+        m: onp.ToJustInt | None = None,
+        w: onp.ToComplex | None = None,
+        a: onp.ToComplex = 1 + 0j,
+    ) -> None: ...
     def __call__(self, /, x: onp.ToComplexND, *, axis: int = -1) -> onp.ArrayND[_Complex]: ...
-    def points(self, /) -> onp.ArrayND[_Complex]: ...
+    def points(self, /) -> onp.Array1D[_Complex]: ...
 
 class ZoomFFT(CZT):
-    w: complex
-    a: complex
-
-    m: int
-    n: int
-
     f1: onp.ToFloat
     f2: onp.ToFloat
     fs: onp.ToFloat
@@ -27,29 +36,41 @@ class ZoomFFT(CZT):
     def __init__(
         self,
         /,
-        n: int,
-        fn: onp.ToFloat | onp.ToFloatND,
-        m: int | None = None,
+        n: onp.ToJustInt,
+        fn: onp.ToFloat | onp.ToFloat1D,
+        m: onp.ToJustInt | None = None,
         *,
         fs: onp.ToFloat = 2,
-        endpoint: bool = False,
+        endpoint: onp.ToBool = False,
     ) -> None: ...
 
-def czt_points(m: int, w: onp.ToComplex | None = None, a: onp.ToComplex = ...) -> onp.ArrayND[_Complex]: ...
+#
+def _validate_sizes(n: onp.ToJustInt, m: onp.ToJustInt | None) -> int | np.integer[Any]: ...
+
+#
+def czt_points(
+    m: onp.ToJustInt,
+    w: onp.ToComplex | None = None,
+    a: onp.ToComplex = 1 + 0j,
+) -> onp.Array1D[_Complex]: ...
+
+#
 def czt(
     x: onp.ToComplexND,
-    m: int | None = None,
+    m: onp.ToJustInt | None = None,
     w: onp.ToComplex | None = None,
     a: onp.ToComplex = 1 + 0j,
     *,
-    axis: int = -1,
+    axis: op.CanIndex = -1,
 ) -> onp.ArrayND[_Complex]: ...
+
+#
 def zoom_fft(
     x: onp.ToComplexND,
     fn: onp.ToFloatND | onp.ToFloat,
-    m: int | None = None,
+    m: onp.ToJustInt | None = None,
     *,
-    fs: int = 2,
-    endpoint: bool = False,
-    axis: int = -1,
-) -> onp.ArrayND[_Float | _Complex]: ...
+    fs: onp.ToFloat = 2,
+    endpoint: onp.ToBool = False,
+    axis: op.CanIndex = -1,
+) -> onp.ArrayND[_Complex]: ...

--- a/scipy-stubs/signal/_filter_design.pyi
+++ b/scipy-stubs/signal/_filter_design.pyi
@@ -1,10 +1,10 @@
-from collections.abc import Callable
-from typing import Literal, TypeAlias, overload
+from collections.abc import Callable, Sequence
+from typing import Any, Literal as L, TypeAlias, overload
+from typing_extensions import TypeVar
 
 import numpy as np
 import optype as op
 import optype.numpy as onp
-from scipy._typing import Untyped
 
 __all__ = [
     "BadCoefficients",
@@ -56,19 +56,46 @@ __all__ = [
     "zpk2tf",
 ]
 
+_Floating: TypeAlias = np.floating[Any]
+_CFloating: TypeAlias = np.complexfloating[Any, Any]
+
+_Floating1D: TypeAlias = onp.Array1D[np.floating[Any]]
+_FloatingND: TypeAlias = onp.ArrayND[np.floating[Any]]
 _Float1D: TypeAlias = onp.Array1D[np.float64]
+_Float2D: TypeAlias = onp.Array2D[np.float64]
 _FloatND: TypeAlias = onp.ArrayND[np.float64]
 _Complex1D: TypeAlias = onp.Array1D[np.complex128]
 _ComplexND: TypeAlias = onp.ArrayND[np.complex128]
 _Inexact1D: TypeAlias = onp.Array1D[np.float64 | np.complex128]
 _InexactND: TypeAlias = onp.ArrayND[np.float64 | np.complex128]
 
+_SCT_z = TypeVar("_SCT_z", bound=np.generic)
+_SCT_p = TypeVar("_SCT_p", bound=np.generic, default=np.complex128)
+_SCT_k = TypeVar("_SCT_k", bound=np.generic | float, default=np.float64)
+_ZPK: TypeAlias = tuple[onp.Array1D[_SCT_z], onp.Array1D[_SCT_p], _SCT_k]
+
+_SCT_ba = TypeVar("_SCT_ba", bound=np.floating[Any], default=np.float64)
+_Ba1D: TypeAlias = tuple[onp.Array1D[_SCT_ba], onp.Array1D[_SCT_ba]]
+_Ba2D: TypeAlias = tuple[onp.Array2D[_SCT_ba], onp.Array1D[_SCT_ba]]
+
+# excludes `float16` and `longdouble`
+_ToFloat: TypeAlias = float | np.float32 | np.float64 | np.integer[Any]
+_ToFloat1D: TypeAlias = Sequence[_ToFloat] | onp.CanArrayND[np.float32 | np.float64 | np.integer[Any]]
+_ToFloat2D: TypeAlias = Sequence[_ToFloat1D] | onp.CanArrayND[np.float32 | np.float64 | np.integer[Any]]
+
+_FType0: TypeAlias = L["butter", "cheby1", "cheby2", "ellip"]
+_FType: TypeAlias = _FType0 | L["bessel"]
+_BType0: TypeAlias = L["bandpass", "lowpass", "highpass", "bandstop"]
+_BType: TypeAlias = _BType0 | L["band", "pass", "bp", "bands", "stop", "bs", "low", "lp", "l", "high", "hp", "h"]
+_Pairing: TypeAlias = L["nearest", "keep_odd", "minimal"]
+_Normalization: TypeAlias = L["phase", "delay", "mag"]
+
 ###
 
 class BadCoefficients(UserWarning): ...
 
 #
-def findfreqs(num: onp.ToComplex1D, den: onp.ToComplex1D, N: op.CanIndex, kind: Literal["ba", "zp"] = "ba") -> _Float1D: ...
+def findfreqs(num: onp.ToComplex1D, den: onp.ToComplex1D, N: op.CanIndex, kind: L["ba", "zp"] = "ba") -> _Float1D: ...
 
 #
 @overload  # worN: real
@@ -151,7 +178,7 @@ def group_delay(
     w: op.CanIndex | onp.ToFloat1D | None = 512,
     whole: op.CanBool = False,
     fs: onp.ToFloat = ...,  # 2 * pi
-) -> tuple[_Float1D, _Float1D]: ...
+) -> _Ba1D: ...
 @overload  # w: complex
 def group_delay(
     system: tuple[onp.ToComplex1D, onp.ToComplex1D],
@@ -178,146 +205,616 @@ def freqz_sos(
 
 sosfreqz = freqz_sos
 
-# TODO(jorenham): https://github.com/jorenham/scipy-stubs/issues/99
+#
+def tf2zpk(b: _ToFloat1D, a: _ToFloat1D) -> _ZPK[np.float64 | np.complex128] | _ZPK[np.complex64, np.complex64, np.float32]: ...
+def tf2sos(b: _ToFloat1D, a: _ToFloat1D, pairing: _Pairing | None = None, *, analog: onp.ToBool = False) -> _Float2D: ...
 
-def tf2zpk(b: Untyped, a: Untyped) -> Untyped: ...
-def zpk2tf(z: Untyped, p: Untyped, k: Untyped) -> Untyped: ...
-def tf2sos(b: Untyped, a: Untyped, pairing: Untyped | None = None, *, analog: bool = False) -> Untyped: ...
-def sos2tf(sos: Untyped) -> Untyped: ...
-def sos2zpk(sos: Untyped) -> Untyped: ...
-def zpk2sos(z: Untyped, p: Untyped, k: Untyped, pairing: Untyped | None = None, *, analog: bool = False) -> Untyped: ...
-def normalize(b: Untyped, a: Untyped) -> Untyped: ...
-def lp2lp(b: Untyped, a: Untyped, wo: float = 1.0) -> Untyped: ...
-def lp2hp(b: Untyped, a: Untyped, wo: float = 1.0) -> Untyped: ...
-def lp2bp(b: Untyped, a: Untyped, wo: float = 1.0, bw: float = 1.0) -> Untyped: ...
-def lp2bs(b: Untyped, a: Untyped, wo: float = 1.0, bw: float = 1.0) -> Untyped: ...
-def bilinear(b: Untyped, a: Untyped, fs: float = 1.0) -> Untyped: ...
+#
+def zpk2tf(z: onp.ToFloat1D, p: onp.ToFloat1D, k: onp.ToFloat) -> _Ba1D: ...
+def zpk2sos(
+    z: onp.ToFloat1D,
+    p: onp.ToFloat1D,
+    k: onp.ToFloat,
+    pairing: _Pairing | None = None,
+    *,
+    analog: onp.ToBool = False,
+) -> _Float2D: ...
+
+#
+@overload
+def normalize(b: onp.ToFloatStrict1D, a: onp.ToFloat1D) -> _Ba1D[_Floating]: ...
+@overload
+def normalize(b: onp.ToFloatStrict2D, a: onp.ToFloat1D) -> _Ba2D[_Floating]: ...
+@overload
+def normalize(b: onp.ToFloat1D | onp.ToFloat2D, a: onp.ToFloat1D) -> _Ba1D[_Floating] | _Ba2D[_Floating]: ...
+
+#
+def sos2tf(sos: onp.ToFloat2D) -> tuple[_Floating1D, _Floating1D]: ...
+def sos2zpk(sos: _ToFloat2D) -> _ZPK[np.complex128, np.complex128, np.float32 | np.float64]: ...
+
+#
+@overload
+def lp2lp(b: onp.ToFloatStrict1D, a: onp.ToFloat1D, wo: onp.ToFloat = 1.0) -> _Ba1D | _Ba1D[np.longdouble]: ...
+@overload
+def lp2lp(b: onp.ToFloatStrict2D, a: onp.ToFloat1D, wo: onp.ToFloat = 1.0) -> _Ba2D | _Ba2D[np.longdouble]: ...
+@overload
+def lp2lp(
+    b: onp.ToFloat1D | onp.ToFloat2D,
+    a: onp.ToFloat1D,
+    wo: onp.ToFloat = 1.0,
+) -> _Ba1D | _Ba1D[np.longdouble] | _Ba2D | _Ba2D[np.longdouble]: ...
+
+#
+def lp2hp(
+    b: onp.ToFloat1D,
+    a: onp.ToFloat1D,
+    wo: onp.ToFloat = 1.0,
+) -> _Ba1D | _Ba1D[np.float16] | _Ba1D[np.float32] | _Ba1D[np.longdouble]: ...
+
+#
+def lp2bp(
+    b: onp.ToFloat1D,
+    a: onp.ToFloat1D,
+    wo: onp.ToFloat = 1.0,
+    bw: onp.ToFloat = 1.0,
+) -> _Ba1D | _Ba1D[np.float32] | _Ba1D[np.longdouble]: ...
+
+#
+def lp2bs(
+    b: onp.ToFloat1D,
+    a: onp.ToFloat1D,
+    wo: onp.ToFloat = 1.0,
+    bw: onp.ToFloat = 1.0,
+) -> _Ba1D | _Ba1D[np.float32] | _Ba1D[np.longdouble]: ...
+
+#
+def lp2lp_zpk(
+    z: onp.ToComplex1D,
+    p: onp.ToComplex1D,
+    k: onp.ToFloat,
+    wo: onp.ToFloat = 1.0,
+) -> _ZPK[np.inexact[Any], _CFloating, _Floating]: ...
+
+#
+def lp2hp_zpk(
+    z: onp.ToComplex1D,
+    p: onp.ToComplex1D,
+    k: onp.ToFloat,
+    wo: onp.ToFloat = 1.0,
+) -> _ZPK[np.inexact[Any], _CFloating, _Floating]: ...
+
+#
+def lp2bp_zpk(
+    z: onp.ToComplex1D,
+    p: onp.ToComplex1D,
+    k: onp.ToFloat,
+    wo: onp.ToFloat = 1.0,
+    bw: onp.ToFloat = 1.0,
+) -> _ZPK[np.inexact[Any], _CFloating, _Floating]: ...
+
+#
+def lp2bs_zpk(
+    z: onp.ToComplex1D,
+    p: onp.ToComplex1D,
+    k: onp.ToFloat,
+    wo: onp.ToFloat = 1.0,
+    bw: onp.ToFloat = 1.0,
+) -> _ZPK[np.inexact[Any], _CFloating, _Floating]: ...
+
+#
+def bilinear(b: onp.ToFloat1D, a: onp.ToFloat1D, fs: onp.ToFloat = 1.0) -> _Ba1D: ...
+
+#
+@overload
+def bilinear_zpk(
+    z: onp.ToFloat1D,
+    p: onp.ToComplex1D,
+    k: onp.ToFloat,
+    fs: onp.ToFloat,
+) -> _ZPK[np.float64, _CFloating] | _ZPK[np.longdouble, _CFloating, np.longdouble]: ...
+@overload
+def bilinear_zpk(
+    z: onp.ToComplex1D,
+    p: onp.ToComplex1D,
+    k: onp.ToFloat,
+    fs: onp.ToFloat,
+) -> _ZPK[np.float64 | np.complex128, _CFloating] | _ZPK[np.longdouble | np.clongdouble, _CFloating, np.longdouble]: ...
+
+#
+@overload  # output="ba" (default)
 def iirdesign(
-    wp: Untyped,
-    ws: Untyped,
-    gpass: Untyped,
-    gstop: Untyped,
-    analog: bool = False,
-    ftype: str = "ellip",
-    output: str = "ba",
-    fs: Untyped | None = None,
-) -> Untyped: ...
+    wp: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    ws: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    gpass: onp.ToFloat,
+    gstop: onp.ToFloat,
+    analog: onp.ToBool = False,
+    ftype: _FType0 = "ellip",
+    output: L["ba"] = "ba",
+    fs: onp.ToFloat | None = None,
+) -> _Ba1D: ...
+@overload  # output="zpk" (positional)
+def iirdesign(
+    wp: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    ws: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    gpass: onp.ToFloat,
+    gstop: onp.ToFloat,
+    analog: onp.ToBool,
+    ftype: _FType0,
+    output: L["zpk"],
+    fs: onp.ToFloat | None = None,
+) -> _ZPK[np.complex128]: ...
+@overload  # output="zpk" (keyword)
+def iirdesign(
+    wp: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    ws: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    gpass: onp.ToFloat,
+    gstop: onp.ToFloat,
+    analog: onp.ToBool = False,
+    ftype: _FType0 = "ellip",
+    *,
+    output: L["zpk"],
+    fs: onp.ToFloat | None = None,
+) -> _ZPK[np.complex128]: ...
+@overload  # output="sos" (positional)
+def iirdesign(
+    wp: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    ws: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    gpass: onp.ToFloat,
+    gstop: onp.ToFloat,
+    analog: onp.ToBool,
+    ftype: _FType0,
+    output: L["sos"],
+    fs: onp.ToFloat | None = None,
+) -> _Float2D: ...
+@overload  # output="sos" (keyword)
+def iirdesign(
+    wp: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    ws: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    gpass: onp.ToFloat,
+    gstop: onp.ToFloat,
+    analog: onp.ToBool = False,
+    ftype: _FType0 = "ellip",
+    *,
+    output: L["sos"],
+    fs: onp.ToFloat | None = None,
+) -> _Float2D: ...
+
+#
+@overload  # output="ba" (default)
 def iirfilter(
-    N: Untyped,
-    Wn: Untyped,
-    rp: Untyped | None = None,
-    rs: Untyped | None = None,
-    btype: str = "band",
-    analog: bool = False,
-    ftype: str = "butter",
-    output: str = "ba",
-    fs: Untyped | None = None,
-) -> Untyped: ...
-def bilinear_zpk(z: Untyped, p: Untyped, k: Untyped, fs: Untyped) -> Untyped: ...
-def lp2lp_zpk(z: Untyped, p: Untyped, k: Untyped, wo: float = 1.0) -> Untyped: ...
-def lp2hp_zpk(z: Untyped, p: Untyped, k: Untyped, wo: float = 1.0) -> Untyped: ...
-def lp2bp_zpk(z: Untyped, p: Untyped, k: Untyped, wo: float = 1.0, bw: float = 1.0) -> Untyped: ...
-def lp2bs_zpk(z: Untyped, p: Untyped, k: Untyped, wo: float = 1.0, bw: float = 1.0) -> Untyped: ...
+    N: onp.ToJustInt,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    rp: onp.ToFloat | None = None,
+    rs: onp.ToFloat | None = None,
+    btype: _BType = "band",
+    analog: onp.ToBool = False,
+    ftype: _FType = "butter",
+    output: L["ba"] = "ba",
+    fs: onp.ToFloat | None = None,
+) -> _Ba1D: ...
+@overload  # output="zpk" (positional)
+def iirfilter(
+    N: onp.ToJustInt,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    rp: onp.ToFloat | None,
+    rs: onp.ToFloat | None,
+    btype: _BType,
+    analog: onp.ToBool,
+    ftype: _FType,
+    output: L["zpk"],
+    fs: onp.ToFloat | None = None,
+) -> _ZPK[np.complex128]: ...
+@overload  # output="zpk" (keyword)
+def iirfilter(
+    N: onp.ToJustInt,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    rp: onp.ToFloat | None = None,
+    rs: onp.ToFloat | None = None,
+    btype: _BType = "band",
+    analog: onp.ToBool = False,
+    ftype: _FType = "butter",
+    *,
+    output: L["zpk"],
+    fs: onp.ToFloat | None = None,
+) -> _ZPK[np.complex128]: ...
+@overload  # output="sos" (positional)
+def iirfilter(
+    N: onp.ToJustInt,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    rp: onp.ToFloat | None,
+    rs: onp.ToFloat | None,
+    btype: _BType,
+    analog: onp.ToBool,
+    ftype: _FType,
+    output: L["sos"],
+    fs: onp.ToFloat | None = None,
+) -> _Float2D: ...
+@overload  # output="sos" (keyword)
+def iirfilter(
+    N: onp.ToJustInt,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    rp: onp.ToFloat | None = None,
+    rs: onp.ToFloat | None = None,
+    btype: _BType = "band",
+    analog: onp.ToBool = False,
+    ftype: _FType = "butter",
+    *,
+    output: L["sos"],
+    fs: onp.ToFloat | None = None,
+) -> _Float2D: ...
+
+#
+@overload  # output="ba" (default)
 def butter(
-    N: Untyped,
-    Wn: Untyped,
-    btype: str = "low",
-    analog: bool = False,
-    output: str = "ba",
-    fs: Untyped | None = None,
-) -> Untyped: ...
+    N: onp.ToJustInt,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    output: L["ba"] = "ba",
+    fs: onp.ToFloat | None = None,
+) -> _Ba1D: ...
+@overload  # output="zpk" (keyword)
+def butter(
+    N: onp.ToJustInt,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    *,
+    output: L["zpk"],
+    fs: onp.ToFloat | None = None,
+) -> _ZPK[np.float64, np.complex128, float]: ...
+@overload  # output="sos" (keyword)
+def butter(
+    N: onp.ToJustInt,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    *,
+    output: L["sos"],
+    fs: onp.ToFloat | None = None,
+) -> _Float2D: ...
+
+#
+@overload  # output="ba" (default)
 def cheby1(
-    N: Untyped,
-    rp: Untyped,
-    Wn: Untyped,
-    btype: str = "low",
-    analog: bool = False,
-    output: str = "ba",
-    fs: Untyped | None = None,
-) -> Untyped: ...
+    N: onp.ToJustInt,
+    rp: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    output: L["ba"] = "ba",
+    fs: onp.ToFloat | None = None,
+) -> _Ba1D: ...
+@overload  # output="zpk" (positional)
+def cheby1(
+    N: onp.ToJustInt,
+    rp: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType,
+    analog: onp.ToBool,
+    output: L["zpk"],
+    fs: onp.ToFloat | None = None,
+) -> _ZPK[np.complex128]: ...
+@overload  # output="zpk" (keyword)
+def cheby1(
+    N: onp.ToJustInt,
+    rp: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    *,
+    output: L["zpk"],
+    fs: onp.ToFloat | None = None,
+) -> _ZPK[np.complex128]: ...
+@overload  # output="sos" (positional)
+def cheby1(
+    N: onp.ToJustInt,
+    rp: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType,
+    analog: onp.ToBool,
+    output: L["sos"],
+    fs: onp.ToFloat | None = None,
+) -> _Float2D: ...
+@overload  # output="sos" (keyword)
+def cheby1(
+    N: onp.ToJustInt,
+    rp: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    *,
+    output: L["sos"],
+    fs: onp.ToFloat | None = None,
+) -> _Float2D: ...
+
+#
+@overload  # output="ba" (default)
 def cheby2(
-    N: Untyped,
-    rs: Untyped,
-    Wn: Untyped,
-    btype: str = "low",
-    analog: bool = False,
-    output: str = "ba",
-    fs: Untyped | None = None,
-) -> Untyped: ...
+    N: onp.ToJustInt,
+    rs: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    output: L["ba"] = "ba",
+    fs: onp.ToFloat | None = None,
+) -> _Ba1D: ...
+@overload  # output="zpk" (positional)
+def cheby2(
+    N: onp.ToJustInt,
+    rs: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType,
+    analog: onp.ToBool,
+    output: L["zpk"],
+    fs: onp.ToFloat | None = None,
+) -> _ZPK[np.complex128]: ...
+@overload  # output="zpk" (keyword)
+def cheby2(
+    N: onp.ToJustInt,
+    rs: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    *,
+    output: L["zpk"],
+    fs: onp.ToFloat | None = None,
+) -> _ZPK[np.complex128]: ...
+@overload  # output="sos" (positional)
+def cheby2(
+    N: onp.ToJustInt,
+    rs: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType,
+    analog: onp.ToBool,
+    output: L["sos"],
+    fs: onp.ToFloat | None = None,
+) -> _Float2D: ...
+@overload  # output="sos" (keyword)
+def cheby2(
+    N: onp.ToJustInt,
+    rs: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    *,
+    output: L["sos"],
+    fs: onp.ToFloat | None = None,
+) -> _Float2D: ...
+
+#
+@overload  # output="ba" (default)
 def ellip(
-    N: Untyped,
-    rp: Untyped,
-    rs: Untyped,
-    Wn: Untyped,
-    btype: str = "low",
-    analog: bool = False,
-    output: str = "ba",
-    fs: Untyped | None = None,
-) -> Untyped: ...
+    N: onp.ToJustInt,
+    rp: onp.ToFloat,
+    rs: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    output: L["ba"] = "ba",
+    fs: onp.ToFloat | None = None,
+) -> _Ba1D: ...
+@overload  # output="zpk" (postitional)
+def ellip(
+    N: onp.ToJustInt,
+    rp: onp.ToFloat,
+    rs: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType,
+    analog: onp.ToBool,
+    output: L["zpk"],
+    fs: onp.ToFloat | None = None,
+) -> _ZPK[np.complex128]: ...
+@overload  # output="zpk" (keyword)
+def ellip(
+    N: onp.ToJustInt,
+    rp: onp.ToFloat,
+    rs: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    *,
+    output: L["zpk"],
+    fs: onp.ToFloat | None = None,
+) -> _ZPK[np.complex128]: ...
+@overload  # output="sos" (postitional)
+def ellip(
+    N: onp.ToJustInt,
+    rp: onp.ToFloat,
+    rs: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType,
+    analog: onp.ToBool,
+    output: L["sos"],
+    fs: onp.ToFloat | None = None,
+) -> _Float2D: ...
+@overload  # output="sos" (keyword)
+def ellip(
+    N: onp.ToJustInt,
+    rp: onp.ToFloat,
+    rs: onp.ToFloat,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    *,
+    output: L["sos"],
+    fs: onp.ToFloat | None = None,
+) -> _Float2D: ...
+
+#
+@overload  # output="ba" (default)
 def bessel(
-    N: Untyped,
-    Wn: Untyped,
-    btype: str = "low",
-    analog: bool = False,
-    output: str = "ba",
-    norm: str = "phase",
-    fs: Untyped | None = None,
-) -> Untyped: ...
+    N: onp.ToJustInt,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    output: L["ba"] = "ba",
+    norm: _Normalization = "phase",
+    fs: onp.ToFloat | None = None,
+) -> _Ba1D: ...
+@overload  # output="zpk" (postitional)
+def bessel(
+    N: onp.ToJustInt,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType,
+    analog: onp.ToBool,
+    output: L["zpk"],
+    norm: _Normalization = "phase",
+    fs: onp.ToFloat | None = None,
+) -> _ZPK[np.float64]: ...
+@overload  # output="zpk" (keyword)
+def bessel(
+    N: onp.ToJustInt,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    *,
+    output: L["zpk"],
+    norm: _Normalization = "phase",
+    fs: onp.ToFloat | None = None,
+) -> _ZPK[np.float64]: ...
+@overload  # output="sos" (postitional)
+def bessel(
+    N: onp.ToJustInt,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType,
+    analog: onp.ToBool,
+    output: L["sos"],
+    norm: _Normalization = "phase",
+    fs: onp.ToFloat | None = None,
+) -> _Float2D: ...
+@overload  # output="sos" (keyword)
+def bessel(
+    N: onp.ToJustInt,
+    Wn: onp.ToFloat | onp.ToFloat1D,  # scalar or length-2
+    btype: _BType = "low",
+    analog: onp.ToBool = False,
+    *,
+    output: L["sos"],
+    norm: _Normalization = "phase",
+    fs: onp.ToFloat | None = None,
+) -> _Float2D: ...
+
+#
+def band_stop_obj(
+    wp: onp.ToFloat,
+    ind: L[0, 1] | np.integer[Any],  # bool doesn't work
+    passb: onp.ArrayND[_Floating | np.integer[Any]],  # 1-d
+    stopb: onp.ArrayND[_Floating | np.integer[Any]],  # 1-d
+    gpass: onp.ToFloat,
+    gstop: onp.ToFloat,
+    type: L["butter", "cheby", "ellip"],
+) -> np.float64 | np.longdouble: ...
+
+#
+@overload
+def buttord(
+    wp: onp.ToFloat,
+    ws: onp.ToFloat | onp.ToFloatND,
+    gpass: onp.ToFloat,
+    gstop: onp.ToFloat,
+    analog: onp.ToBool = False,
+    fs: onp.ToFloat | None = None,
+) -> tuple[int, np.float64 | np.longdouble]: ...
+@overload
+def buttord(
+    wp: onp.ToFloatND,
+    ws: onp.ToFloat | onp.ToFloatND,
+    gpass: onp.ToFloat,
+    gstop: onp.ToFloat,
+    analog: onp.ToBool = False,
+    fs: onp.ToFloat | None = None,
+) -> tuple[int, onp.Array1D[np.float64 | np.longdouble]]: ...
+
+#
+@overload
+def cheb1ord(
+    wp: onp.ToFloat,
+    ws: onp.ToFloat | onp.ToFloatND,
+    gpass: onp.ToFloat,
+    gstop: onp.ToFloat,
+    analog: onp.ToBool = False,
+    fs: onp.ToFloat | None = None,
+) -> tuple[int, _Floating]: ...
+@overload
+def cheb1ord(
+    wp: onp.ToFloatND,
+    ws: onp.ToFloat | onp.ToFloatND,
+    gpass: onp.ToFloat,
+    gstop: onp.ToFloat,
+    analog: onp.ToBool = False,
+    fs: onp.ToFloat | None = None,
+) -> tuple[int, _FloatingND]: ...
+
+#
+@overload
+def cheb2ord(
+    wp: onp.ToFloat,
+    ws: onp.ToFloat | onp.ToFloatND,
+    gpass: onp.ToFloat,
+    gstop: onp.ToFloat,
+    analog: onp.ToBool = False,
+    fs: onp.ToFloat | None = None,
+) -> tuple[int, _Floating]: ...
+@overload
+def cheb2ord(
+    wp: onp.ToFloatND,
+    ws: onp.ToFloat | onp.ToFloatND,
+    gpass: onp.ToFloat,
+    gstop: onp.ToFloat,
+    analog: onp.ToBool = False,
+    fs: onp.ToFloat | None = None,
+) -> tuple[int, _FloatND]: ...  # only nd-output is cast to float64
+
+#
+@overload
+def ellipord(
+    wp: onp.ToFloat,
+    ws: onp.ToFloat | onp.ToFloatND,
+    gpass: onp.ToFloat,
+    gstop: onp.ToFloat,
+    analog: onp.ToBool = False,
+    fs: onp.ToFloat | None = None,
+) -> tuple[int, _Floating]: ...
+@overload
+def ellipord(
+    wp: onp.ToFloatND,
+    ws: onp.ToFloat | onp.ToFloatND,
+    gpass: onp.ToFloat,
+    gstop: onp.ToFloat,
+    analog: onp.ToBool = False,
+    fs: onp.ToFloat | None = None,
+) -> tuple[int, _FloatingND]: ...
+
+#
+
+def buttap(N: onp.ToJustInt) -> tuple[_Float1D, _Complex1D, L[1]]: ...
+def cheb1ap(N: onp.ToJustInt, rp: onp.ToFloat) -> tuple[_Float1D, _Complex1D, np.float64]: ...
+def cheb2ap(N: onp.ToJustInt, rs: onp.ToFloat) -> tuple[_Complex1D, _Complex1D, np.float64]: ...
+def ellipap(N: onp.ToJustInt, rp: onp.ToFloat, rs: onp.ToFloat) -> tuple[_Complex1D, _Complex1D, np.float64]: ...
+def besselap(N: onp.ToJustInt, norm: _Normalization = "phase") -> tuple[_Float1D, _Complex1D, float]: ...
+
+#
+def iirnotch(w0: onp.ToFloat, Q: onp.ToFloat, fs: onp.ToFloat = 2.0) -> _Ba1D: ...
+def iirpeak(w0: onp.ToFloat, Q: onp.ToFloat, fs: onp.ToFloat = 2.0) -> _Ba1D: ...
+def iircomb(
+    w0: onp.ToFloat,
+    Q: onp.ToFloat,
+    ftype: L["notch", "peak"] = "notch",
+    fs: onp.ToFloat = 2.0,
+    *,
+    pass_zero: onp.ToBool = False,
+) -> _Ba1D: ...
+
+#
+def gammatone(
+    freq: onp.ToFloat,
+    ftype: L["fir", "iir"],
+    order: L[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24] | None = None,
+    numtaps: int | None = None,
+    fs: onp.ToFloat | None = None,
+) -> _Ba1D: ...
+
+# ???
 def maxflat() -> None: ...
 def yulewalk() -> None: ...
-def band_stop_obj(
-    wp: Untyped,
-    ind: Untyped,
-    passb: Untyped,
-    stopb: Untyped,
-    gpass: Untyped,
-    gstop: Untyped,
-    type: Untyped,
-) -> Untyped: ...
-def buttord(
-    wp: Untyped,
-    ws: Untyped,
-    gpass: Untyped,
-    gstop: Untyped,
-    analog: bool = False,
-    fs: Untyped | None = None,
-) -> Untyped: ...
-def cheb1ord(
-    wp: Untyped,
-    ws: Untyped,
-    gpass: Untyped,
-    gstop: Untyped,
-    analog: bool = False,
-    fs: Untyped | None = None,
-) -> Untyped: ...
-def cheb2ord(
-    wp: Untyped,
-    ws: Untyped,
-    gpass: Untyped,
-    gstop: Untyped,
-    analog: bool = False,
-    fs: Untyped | None = None,
-) -> Untyped: ...
-def ellipord(
-    wp: Untyped,
-    ws: Untyped,
-    gpass: Untyped,
-    gstop: Untyped,
-    analog: bool = False,
-    fs: Untyped | None = None,
-) -> Untyped: ...
-def buttap(N: Untyped) -> Untyped: ...
-def cheb1ap(N: Untyped, rp: Untyped) -> Untyped: ...
-def cheb2ap(N: Untyped, rs: Untyped) -> Untyped: ...
-def ellipap(N: Untyped, rp: Untyped, rs: Untyped) -> Untyped: ...
-def besselap(N: Untyped, norm: str = "phase") -> Untyped: ...
-def iirnotch(w0: Untyped, Q: Untyped, fs: float = 2.0) -> Untyped: ...
-def iirpeak(w0: Untyped, Q: Untyped, fs: float = 2.0) -> Untyped: ...
-def iircomb(w0: Untyped, Q: Untyped, ftype: str = "notch", fs: float = 2.0, *, pass_zero: bool = False) -> Untyped: ...
-def gammatone(
-    freq: Untyped,
-    ftype: Untyped,
-    order: Untyped | None = None,
-    numtaps: Untyped | None = None,
-    fs: Untyped | None = None,
-) -> Untyped: ...


### PR DESCRIPTION
This affects the following public `scipy.signal` members:

- `CZT`
- `czt`
- `czt_points`
- `ZoomFFT`
- `zoom_fft`
- `iirdesign`
- `iirfilter`
- `iirnotch`
- `iirpeak`
- `iircomb`
- `gammatone`
- `butter`
- `cheby{1,2}`
- `ellip`
- `bessel`
- `buttord`
- `cheb{1,2}ord`
- `ellipord`
- `band_stop_obj`
- `buttap`
- `cheb{1,2}ap`
- `ellipap`
- `besselap`
- `normalize`
- `tf2{zpk,sos}`
- `spk2{tf,sos}`
- `sos2{tf,zpk}`
- `lp2{lp,hp,bp,bs}`
- `lp2{lp,hp,bp,bs}_zpk`
- `bilinear`
- `bilinear_zpk`

towards #99 (-157)