### PR TITLE
👷 PyPI trusted publishing workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,27 @@
+name: Build a new release, and publish to PyPI
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  pypi-publish:
+    name: Publish release to PyPI
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment:
+      name: pypi
+      url: https://pypi.org/p/scipy-stubs
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: setup uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - name: uv build
+        run: uv build
+      - name: publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Unlike optype, which triggers on tag push, this one will trigger on release creation (which hopefully also includes draft releases). Let's see which one I like better.

closes #263