### PR TITLE
👷 exclude unsupported test matrix version combinations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -56,9 +57,11 @@ jobs:
     needs: generate-matrix
     timeout-minutes: 3
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -72,7 +75,6 @@ jobs:
         run: uv tool install tox --with tox-uv
 
       - name: Install dependencies
-        continue-on-error: true
         run: |
           rm -rf .venv
           uv add --no-build-package=numpy "numpy<=${{ matrix.numpy }}"


### PR DESCRIPTION
This reduces the required jobs by 3, resulting in ~33% faster CI runs.